### PR TITLE
Examples describing standard reference databases

### DIFF
--- a/examples/nist-asd.xml
+++ b/examples/nist-asd.xml
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://schema.bipm.org/xml/imres/1.0wd">
+<imr:Resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns:imr="http://schema.bipm.org/xml/imres/1.0wd"
+              xsi:type="imr:MetrologyData" status="active">
           
+   <resourceType> Dataset: Database </resourceType>
+
    <title>NIST Atomic Spectra Database</title>
    <altTitle type="Subtitle">NIST Standard Reference Database #78</altTitle>
+   <altTitle type="Abbreviation">NIST-ASD</altTitle>
+   <altTitle type="Abbreviation">SRD#78</altTitle>
+   <homeURL>http://www.nist.gov/pml/data/asd.cfm</homeURL>
+   <sponsoringCountry abbrev="USA">United States of America</sponsoringCountry>
+
    <creator>
      <name>Alexander Kramida</name>
      <affiliation>NIST</affiliation>
@@ -36,6 +44,7 @@
      <name>Edward B. Saloman</name>
      <affiliation>NIST</affiliation>
    </contributor>
+
    <contact>
      <name>Yuri Ralchenko</name>
      <emailAddress>yuri.ralchenko@nist.gov</emailAddress>
@@ -63,8 +72,12 @@
      atoms and atomic ions. 
    </description>
 
-   <resourceType> Dataset: Database </resourceType>
-
    <publisher>US National Institute of Standards and Technology (NIST)</publisher>
    <publicationYear> 2014 </publicationYear>
-</Resource>
+
+   <access>
+     <rights>public</rights>
+     <termsURL>http://www.nist.gov/open/license.cfm</termsURL>
+   </access>
+
+</imr:Resource>

--- a/examples/nist-srd4.xml
+++ b/examples/nist-srd4.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<imr:Resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns:imr="http://schema.bipm.org/xml/imres/1.0wd"
+              xmlns:imd="http://schema.bipm.org/xml/imres/data/1.0wd"
+              xsi:type="imd:Database" status="active">
+          
+   <resourceType>Dataset: Database</resourceType>
+
+   <title>NIST Thermophysical Properties of Hydrocarbon Mixtures Database</title>
+   <altTitle type="Subtitle">NIST Standard Reference Database #4</altTitle>
+   <altTitle type="Abbreviation">SRD#4</altTitle>
+   <identifier type="DOI">10.18434/T4CC76</identifier>
+   <homeURL>http://dx.doi.org/10.18434/T4CC76</homeURL>
+   <sponsoringCountry abbrev="USA">United States of America</sponsoringCountry>
+
+   <contributor type="Sponsor">
+     <name>The NIST Supercritical Fluid Property Consortium</name>
+   </contributor>
+
+   <contact>
+     <name>Marcia Huber</name>
+     <emailAddress>marcia.huber@nist.gov</emailAddress>
+   </contact>
+
+   <subject>Chemical engineering</subject>
+   <subject>chemical manufacturing</subject>
+   <subject>chemical property</subject>
+   <subject>chemistry</subject>
+   <subject>dielectric constants</subject>
+   <subject>equation of state</subject>
+   <subject>fluids</subject>
+   <subject>heat capacity</subject>
+   <subject>hydrocarbons</subject>
+   <subject>LNG</subject>
+   <subject>mixtures</subject>
+   <subject>natural gas</subject>
+   <subject>petrochemical</subject>
+   <subject>phase equilibria</subject>
+   <subject>thermal conductivity</subject>
+   <subject>thermodynamics</subject>
+   <subject>thermophysics</subject>
+   <subject>transport property</subject>
+   <subject>viscosity</subject>
+
+   <description>
+     This database provides calculated predicted values for thermodynamic and 
+     transport properties of pure fluids and fluid mixtures containing up to 
+     20 components.  The components are selected from a database of 210 
+     components, mostly hydrocarbons.  It provides these values via an 
+     interactive software program called SUPERTRAPP.   SUPERTRAPP performs 
+     phase equilibria calculations and gives the thermophysical properties of 
+     all phases and the feed. These results include the equilibrium properties
+     of density, compressibility factor, enthalpy, entropy, Cp, Cp/Cv, sound 
+     speed, and Joule-Thomson coefficient as well the transport properties of 
+     viscosity and thermal conductivity.  Note that many of the fluids contained 
+     in NIST4 are also available in the REFPROP database (SRD#23).  The REFPROP 
+     database is recommended over NIST4 when REFPROP contains the fluids of 
+     interest.
+   </description>
+
+   <publisher>US National Institute of Standards and Technology (NIST)</publisher>
+   <publicationYear>1990</publicationYear>
+
+   <measures>
+     <propertyClass>transport</propertyClass>
+     <propertyClass>thermal</propertyClass>
+     <propertyClass>mechanical</propertyClass>
+   </measures>
+
+   <access>
+     <rights>fee-required</rights>
+     <termsURL>http://www.nist.gov/open/license.cfm</termsURL>
+     <via xsi:type="imr:Media">
+       <method>media</method>
+       <mediaType>CDROM</mediaType>
+     </via>
+   </access>
+
+</imr:Resource>

--- a/examples/nist.xml
+++ b/examples/nist.xml
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<imo:Resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns:imo="http://schema.bipm.org/xml/imres/org/1.0wd">
+<imr:Resource xsi:type="nmi:MetrologyInstitute"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns:imr="http://schema.bipm.org/xml/imres/1.0wd"
+              xmlns:nmi="http://schema.bipm.org/xml/imres/nmi/1.0wd"
+              status="active" localid="####">
           
-   <resourceType>Other: Organization</resourceType>
+   <resourceType>Organization: Metrology Institute</resourceType>
    <title>US National Institute of Standards and Technology</title>
-   <altTitle type="AlternativeTitle">NIST</altTitle>
+   <altTitle type="Abbreviation">NIST</altTitle>
+   <homeURL>https://www.nist.gov/</homeURL>
+   <sponsoringCountry abbrev="USA">United States of America</sponsoringCountry>
+
    <contact>
      <name>Robert Hanisch</name>
      <emailAddress>robert.hanisch@nist.gov</emailAddress>
@@ -43,8 +49,6 @@
      collections.  
    </description>
 
-   <referenceURL>https://www.nist.gov/</referenceURL>
-
    <date type="Created">1901</date>
 
-</imo:Resource>
+</imr:Resource>

--- a/examples/schemaLocation.txt
+++ b/examples/schemaLocation.txt
@@ -2,3 +2,4 @@ http://schema.bipm.org/xml/imres/1.0wd ../schemas/imresource.xsd
 http://schema.bipm.org/xml/imres/gen/1.0wd ../schemas/imr-generic.xsd
 http://schema.bipm.org/xml/imres/org/1.0wd ../schemas/imr-organization.xsd
 http://schema.bipm.org/xml/imres/nmi/1.0wd ../schemas/imr-nmi.xsd
+http://schema.bipm.org/xml/imres/data/1.0wd ../schemas/imr-data.xsd

--- a/examples/schemaLocation.txt
+++ b/examples/schemaLocation.txt
@@ -1,3 +1,4 @@
 http://schema.bipm.org/xml/imres/1.0wd ../schemas/imresource.xsd
 http://schema.bipm.org/xml/imres/gen/1.0wd ../schemas/imr-generic.xsd
 http://schema.bipm.org/xml/imres/org/1.0wd ../schemas/imr-organization.xsd
+http://schema.bipm.org/xml/imres/nmi/1.0wd ../schemas/imr-nmi.xsd

--- a/schemas/imr-data.xsd
+++ b/schemas/imr-data.xsd
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://schema.bipm.org/xml/imres/data/1.0wd" 
+           xmlns="http://www.w3.org/2001/XMLSchema" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns:imr="http://schema.bipm.org/xml/imres/1.0wd" 
+           xmlns:imi="http://schema.bipm.org/xml/imres/nmi/1.0wd" 
+           xmlns:am="http://schema.nist.gov/xml/nmrr.schema.annot" 
+           elementFormDefault="unqualified" 
+           attributeFormDefault="unqualified" version="0.1">
+
+   <xs:annotation>
+      <xs:documentation>
+        An IMRR metadata extension to define the Data related resource types.
+      </xs:documentation>
+      <xs:documentation>
+        This schema draws on concepts and patterns used in the
+        DataCite metadata Schema for the Publication and Citation
+        of Research Data (https://schema.datacite.org/meta/kernel-3/).
+      </xs:documentation>
+   </xs:annotation>
+
+   <xs:import namespace="http://schema.bipm.org/xml/imres/1.0wd"/>
+
+   <xs:complexType name="Database">
+      <xs:annotation>
+         <xs:documentation>
+           a Resource description with resourceType fixed to Organization
+         </xs:documentation>
+      </xs:annotation>
+
+      <xs:complexContent>
+        <xs:restriction base="imr:MetrologyData">
+          <xs:sequence>
+             <xs:element name="resourceType" type="imr:nonemptycontentStringType"
+                         fixed="Dataset: Database"/>
+
+             <xs:element name="title" type="imr:nonemptycontentStringType"/>
+             <xs:element name="altTitle" type="imr:AltTitle"
+                         minOccurs="0" maxOccurs="unbounded"/>
+             <xs:element name="identifier" type="imr:Identifier" minOccurs="0"/>
+             <xs:element name="alternateIdentifier" type="imr:Identifier"
+                         minOccurs="0" maxOccurs="unbounded"/>
+             <xs:element name="homeURL" type="xs:anyURI"/>
+             <xs:element name="sponsoringCountry" minOccurs="0" 
+                         maxOccurs="unbounded" type="imr:Country"/>
+             <xs:element name="creator" type="imr:Entity"
+                         minOccurs="0" maxOccurs="unbounded"/>
+             <xs:element name="contributor" type="imr:Contributor" 
+                         minOccurs="0" maxOccurs="unbounded"/>
+             <xs:element name="contact" type="imr:Contact" 
+                         maxOccurs="unbounded"/>
+             <xs:element name="subject" type="imr:Subject" 
+                         maxOccurs="unbounded"/>
+             <xs:element name="description" type="xs:token" 
+                         maxOccurs="unbounded"/>
+             <xs:element name="date" type="imr:Date" 
+                         minOccurs="0" maxOccurs="unbounded"/>
+             <xs:element name="publisher" type="imr:nonemptycontentStringType"/>
+             <xs:element name="publicationYear" type="imr:Year"/>
+             <xs:element name="measures" type="imr:Measures" minOccurs="0"/>
+             <xs:element name="access" type="imr:Access"/>
+         </xs:sequence>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+
+
+</xs:schema>
+   

--- a/schemas/imr-nmi.xsd
+++ b/schemas/imr-nmi.xsd
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema targetNamespace="http://schema.bipm.org/xml/imres/org/1.0wd" 
+<xs:schema targetNamespace="http://schema.bipm.org/xml/imres/nmi/1.0wd" 
            xmlns="http://www.w3.org/2001/XMLSchema" 
            xmlns:xs="http://www.w3.org/2001/XMLSchema" 
            xmlns:imr="http://schema.bipm.org/xml/imres/1.0wd" 
-           xmlns:imo="http://schema.bipm.org/xml/imres/org/1.0wd" 
+           xmlns:imi="http://schema.bipm.org/xml/imres/nmi/1.0wd" 
            xmlns:am="http://schema.nist.gov/xml/nmrr.schema.annot" 
            elementFormDefault="unqualified" 
            attributeFormDefault="unqualified" version="0.1">
 
    <xs:annotation>
       <xs:documentation>
-        An IMRR metadata extension to define the Organization resource type.
+        An IMRR metadata extension to define the NMI resource type.
       </xs:documentation>
       <xs:documentation>
         This schema draws on concepts and patterns used in the
@@ -21,7 +21,7 @@
 
    <xs:import namespace="http://schema.bipm.org/xml/imres/1.0wd"/>
 
-   <xs:complexType name="Organization">
+   <xs:complexType name="MetrologyInstitute">
       <xs:annotation>
          <xs:documentation>
            a Resource description with resourceType fixed to Organization
@@ -32,16 +32,17 @@
         <xs:restriction base="imr:Resource">
           <xs:sequence>
              <xs:element name="resourceType" type="imr:nonemptycontentStringType"
-                         fixed="Organization"/>
+                         fixed="Organization: Metrology Institute"/>
 
              <xs:element name="title" type="imr:nonemptycontentStringType"/>
              <xs:element name="altTitle" type="imr:AltTitle"
                          minOccurs="0" maxOccurs="unbounded"/>
-             <xs:element name="identifier" type="xs:token" minOccurs="0"/>
-             <xs:element name="alternateIdentifier" type="xs:token"
+             <xs:element name="identifier" type="imr:Identifier" minOccurs="0"/>
+             <xs:element name="alternateIdentifier" type="imr:Identifier"
                          minOccurs="0" maxOccurs="unbounded"/>
-             <xs:element name="sponsoringCountry" type="imr:nonemptycontentStringType"
-                         minOccurs="0" maxOccurs="unbounded"/>
+             <xs:element name="homeURL" type="xs:anyURI"/>
+             <xs:element name="sponsoringCountry" minOccurs="0" 
+                         maxOccurs="unbounded" type="imr:Country"/>
              <xs:element name="creator" type="imr:Entity"
                          minOccurs="0" maxOccurs="unbounded"/>
              <xs:element name="contributor" type="imr:Contributor" 

--- a/schemas/imresource.xsd
+++ b/schemas/imresource.xsd
@@ -21,6 +21,14 @@
    <xs:import namespace="http://www.w3.org/XML/1998/namespace"
               schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
    
+   <xs:element name="Resource" type="imr:Resource">
+      <xs:annotation>
+         <xs:documentation>
+           a root element for describing a registered resource 
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
    <xs:complexType name="Resource">
       <xs:annotation>
          <xs:documentation>
@@ -67,7 +75,7 @@
             </xs:annotation>
          </xs:element>
 
-         <xs:element name="identifier" type="xs:token" minOccurs="0">
+         <xs:element name="identifier" type="imr:Identifier" minOccurs="0">
             <xs:annotation>
                <xs:appinfo>
                  <am:dcterm>identifier</am:dcterm>
@@ -80,7 +88,7 @@
             </xs:annotation>
          </xs:element>
 
-         <xs:element name="alternateIdentifier" type="xs:token"
+         <xs:element name="alternateIdentifier" type="imr:Identifier"
                      minOccurs="0" maxOccurs="unbounded">
             <xs:annotation>
                <xs:appinfo>
@@ -89,6 +97,44 @@
                <xs:documentation>
                   an additional identifier that refers to this
                   resource (in another identifier scheme)
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+
+         <xs:element name="homeURL" type="xs:anyURI">
+            <xs:annotation>
+               <xs:appinfo>
+                 <label>Organization home page</label>
+               </xs:appinfo>
+               <xs:documentation>
+                  URL pointing to a human-readable document that represents
+                  the best source of more information about the resource
+               </xs:documentation>
+               <xs:documentation>
+                  This URL typically points to an HTML page that not
+                  only provides an introduction to the resource but
+                  links for both more information and access to the
+                  resources components.
+               </xs:documentation>
+               <xs:documentation>
+                  It is recommended in cases where a persistent
+                  identifier has been assigned to the resource
+                  (namely a DOI, an ARK id, or a PURL) that the URL
+                  form of the identifier be provided here.  
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+
+         <xs:element name="sponsoringCountry" minOccurs="0" maxOccurs="unbounded"
+                     type="imr:Country">
+            <xs:annotation>
+               <xs:appinfo>
+                 <am:dcterm>Contributor</am:dcterm>
+                 <am:dataciteproperty>Contributor</am:dataciteproperty>
+               </xs:appinfo>           
+               <xs:documentation>
+                  a country that provided for this resource and/or
+                  which this resource represents.
                </xs:documentation>
             </xs:annotation>
          </xs:element>
@@ -164,15 +210,6 @@
             </xs:annotation>
          </xs:element>
 
-         <xs:element name="referenceURL" type="xs:anyURI">
-            <xs:annotation>
-               <xs:documentation>
-                  URL pointing to a human-readable document describing this 
-                  resource.   
-               </xs:documentation>
-            </xs:annotation>
-         </xs:element>
-
          <xs:element name="date" type="imr:Date" 
                      minOccurs="0" maxOccurs="unbounded">
             <xs:annotation>
@@ -200,6 +237,41 @@
         <xs:simpleType>
           <xs:restriction base="xs:string"/>                      
         </xs:simpleType>
+      </xs:attribute>
+
+      <xs:attribute name="status" use="required">
+         <xs:annotation>
+            <xs:documentation>
+              a tag indicating whether this resource is believed to be still
+              actively maintained.
+            </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:enumeration value="active">
+                 <xs:annotation>
+                   <xs:documentation>
+                      resource is believed to be currently maintained, and its
+                      description is up to date (default). 
+                   </xs:documentation>
+                 </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="inactive">
+                 <xs:annotation>
+                   <xs:documentation>
+                     resource is apparently not being maintained at the present.
+                   </xs:documentation>
+                 </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="deleted">
+                 <xs:annotation>
+                   <xs:documentation>
+                      resource publisher has explicitly deleted the resource.
+                   </xs:documentation>
+                 </xs:annotation>
+               </xs:enumeration>
+            </xs:restriction>
+         </xs:simpleType>
       </xs:attribute>
 
    </xs:complexType>
@@ -243,7 +315,98 @@
        </xs:extension>
      </xs:complexContent>
    </xs:complexType>
+   
+   <xs:complexType name="MetrologyData">
+     <xs:annotation>
+        <xs:documentation>
+          an identified, described, and discoverable component of the 
+          distributed data environment. 
+        </xs:documentation>
+     </xs:annotation>
+     <xs:complexContent>
+       <xs:extension base="imr:PublishedResource">
+         <xs:sequence>
 
+           <xs:element name="measures" type="imr:Measures" minOccurs="0">
+              <xs:annotation>
+                 <xs:documentation>
+                   Information describing the variety of measurements 
+                   available in this data
+                 </xs:documentation>
+              </xs:annotation>
+           </xs:element>
+
+           <xs:element name="access" type="imr:Access">
+              <xs:annotation>
+                 <xs:documentation>
+                   Information describing how to access the resource and its 
+                   features and capabilities.  
+                 </xs:documentation>
+              </xs:annotation>
+           </xs:element>
+
+         </xs:sequence>
+       </xs:extension>
+     </xs:complexContent>
+   </xs:complexType>
+
+   <xs:complexType name="Identifier">
+     <xs:annotation>
+       <xs:documentation>
+         a contributor that plays one of the roles defined by the
+         datacite metadata schema.  
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:simpleContent>
+       <xs:extension base="xs:string">
+ 	  <xs:attribute name="type" type="imr:IdentifierType" use="required">
+             <xs:annotation>
+                <xs:documentation>
+                  The type of title; either "AlternativeTitle",
+                  "Subtitle", or "TranslatedTitle"
+                </xs:documentation>
+                <xs:documentation>
+                  Use xml:lang if type is "TranslatedTitle"
+                </xs:documentation>
+             </xs:annotation>
+ 	  </xs:attribute>      
+         
+       </xs:extension>
+     </xs:simpleContent>
+
+   </xs:complexType>
+
+   <xs:simpleType name="IdentifierType">
+     <xs:annotation>
+       <xs:documentation>
+         The identifier system within which this identifier was minted.
+       </xs:documentation>
+       <xs:documentation>
+         Typical systems include DOI, ARK, ORCID, PURL, or URL.  
+       </xs:documentation>
+     </xs:annotation>
+     <xs:restriction base="xs:string">
+       <xs:enumeration value="ARK"/>
+       <xs:enumeration value="arXiv"/>
+       <xs:enumeration value="bibcode"/>
+       <xs:enumeration value="DOI"/>
+       <xs:enumeration value="EAN13"/>
+       <xs:enumeration value="EISSN"/>
+       <xs:enumeration value="Handle"/>
+       <xs:enumeration value="ISBN"/>
+       <xs:enumeration value="ISSN"/>
+       <xs:enumeration value="ISTC"/>
+       <xs:enumeration value="LISSN"/>
+       <xs:enumeration value="LSID"/>
+       <xs:enumeration value="PMID"/>
+       <xs:enumeration value="PURL"/>
+       <xs:enumeration value="UPC"/>
+       <xs:enumeration value="URL"/>
+       <xs:enumeration value="URN"/>
+     </xs:restriction>
+   </xs:simpleType>
+   
    <xs:complexType name="AltTitle">
       <xs:annotation>
          <xs:documentation>
@@ -305,8 +468,37 @@
          </xs:annotation>
        </xs:enumeration>
          
+       <xs:enumeration value="Abbreviation">
+         <xs:annotation>
+           <xs:documentation>
+             title value represents an abbreviation of the title 
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+         
      </xs:restriction>
    </xs:simpleType>
+
+   <xs:complexType name="Country">
+      <xs:annotation>
+         <xs:documentation>
+           A country's name
+         </xs:documentation>
+      </xs:annotation>
+
+      <xs:simpleContent>
+         <xs:extension base="imr:nonemptycontentStringType">
+ 	    <xs:attribute name="abbrev" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation>
+                    An abbreviated version of the country's name, e.g. USA, UK
+                  </xs:documentation>
+               </xs:annotation>
+ 	    </xs:attribute>      
+         </xs:extension>
+      </xs:simpleContent>
+
+   </xs:complexType>
 
    <xs:complexType name="Entity">
       <xs:annotation>
@@ -938,7 +1130,415 @@
      </xs:restriction>
    </xs:simpleType>
 
-   
+   <xs:complexType name="Measures">
+      <xs:annotation>
+         <xs:documentation>
+           a container for metrology-specific metadata
+         </xs:documentation>
+      </xs:annotation>
+
+      <xs:sequence>
+
+        <xs:element name="propertyClass" type="imr:PropertyClass"
+                    minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:appinfo>
+                 <label>Class of properties measured: </label>
+               </xs:appinfo>
+               <xs:documentation>
+                  a category of property that is sampled by the contained data
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         
+         <xs:element name="substance" type="xs:string"
+                     minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:appinfo>
+                 <label>Substance (or constituent) sampled or addressed: </label>
+                 <tooltip>Provide </tooltip>
+               </xs:appinfo>
+               <xs:documentation>
+                 a substance or substance constituent that was sampled,
+                 measured, or addressed in this data.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:simpleType name="PropertyClass">
+     <xs:annotation>
+       <xs:documentation>
+         allowed values representing categories of material physical properties
+       </xs:documentation>
+     </xs:annotation>
+     <xs:restriction base="xs:token">
+       <xs:enumeration value="optical">
+         <xs:annotation>
+           <xs:documentation>
+             property describes out a material interacts with electromagnetic 
+             radiation.
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="mechanical">
+         <xs:annotation>
+           <xs:documentation>
+             property describes a sample material's response to an external 
+             influence causing plastic deformation or destruction.
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="thermal">
+         <xs:annotation>
+           <xs:documentation>
+             property describing a materials response to heat, including the 
+             transfer of heat through the material and thermophysical properties
+             (those that vary with temperature without changing the material's 
+             identity. 
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="structural">
+         <xs:annotation>
+           <xs:documentation>
+             properties describing the relative locations of a material's 
+             constituent atoms or molecules. 
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="simulated">
+         <xs:annotation>
+           <xs:documentation>
+             a property or parameter describing a material's state as calculated
+             in a computational simulation.
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="transport">
+         <xs:annotation>
+           <xs:documentation>
+             a property describing the transport of mass through a material.
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="deteriorative">
+         <xs:annotation>
+           <xs:documentation>
+             a property related to material deterioration
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="chemical">
+         <xs:annotation>
+           <xs:documentation>
+             a property describing the chemical behavior or structure, including
+             related to its electronic states.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+     </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="Access">
+      <xs:annotation>
+         <xs:documentation>
+           a container for metrology-specific metadata
+         </xs:documentation>
+      </xs:annotation>
+
+      <xs:sequence>
+
+        <xs:element name="rights" type="imr:Rights"
+                    minOccurs="1" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <am:dcterm>Rights</am:dcterm>
+            </xs:appinfo>           
+            <xs:documentation>
+              Information about the held in and over the resource.
+            </xs:documentation>
+            <xs:documentation>
+              This should be repeated for all Rights values that apply.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+
+        <xs:element name="licenseName" type="xs:token" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <am:dcterm>License</am:dcterm>
+            </xs:appinfo>           
+            <xs:documentation>
+              The common name for the license that covers access to this
+              data resource.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        
+        <xs:element name="termsURL" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:appinfo>
+              <am:dcterm>Rights</am:dcterm>
+            </xs:appinfo>           
+            <xs:documentation>
+              A public URL to a document describing the terms of access
+              for the resource.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+
+        <xs:element name="download" type="imr:Download"
+                    minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>
+              a category of property that is sampled by the contained data
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+         
+        <xs:element name="serviceAPI" type="imr:ServiceAPI"
+                    minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>
+              a category of property that is sampled by the contained data
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+         
+        <xs:element name="media" type="imr:Media"
+                    minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>
+              a category of property that is sampled by the contained data
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+         
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="ServiceAPI">
+      <xs:annotation>
+         <xs:documentation>
+           a container for information on accessing the data via a service API
+         </xs:documentation>
+      </xs:annotation>
+
+      <xs:sequence>
+
+        <xs:element name="description" type="xs:token" minOccurs="0">
+           <xs:annotation>
+              <xs:documentation>
+                A summary of what the service API enables
+              </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+         
+        <xs:element name="documentationURL" type="xs:anyURI" minOccurs="0">
+           <xs:annotation>
+              <xs:documentation>
+                The URL to a web page that describes how to use the service.  
+              </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+         
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="Media">
+      <xs:annotation>
+         <xs:documentation>
+           a container for information on accessing the data via a service API
+         </xs:documentation>
+      </xs:annotation>
+
+      <xs:sequence>
+
+        <xs:element name="mediaType" type="xs:token"
+                    minOccurs="1" maxOccurs="unbounded">
+           <xs:annotation>
+              <xs:documentation>
+                The type of media provided
+              </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+         
+        <xs:element name="description" type="xs:token" minOccurs="0">
+           <xs:annotation>
+              <xs:documentation>
+                A summary of what the service API enables
+              </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+         
+        <xs:element name="requestURL" type="xs:anyURI" minOccurs="0">
+           <xs:annotation>
+              <xs:documentation>
+                The URL to a web page that describes how to use the service.  
+              </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+         
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="Download">
+      <xs:annotation>
+         <xs:documentation>
+           a container for metrology-specific metadata
+         </xs:documentation>
+      </xs:annotation>
+
+      <xs:sequence>
+
+        <xs:element name="description" type="xs:token" minOccurs="0">
+           <xs:annotation>
+              <xs:documentation>
+                A summary of what the download URL delivers
+              </xs:documentation>
+              <xs:documentation>
+                Providing a description is recommended if more than one
+                portal is available.  If the accessURL's use attribute is set 
+                to "base", describe what is expected to be appended to the URL
+                to retrieve individual files.  
+              </xs:documentation>
+           </xs:annotation>
+        </xs:element>
+
+        <xs:element name="format" type="xs:token" minOccurs="0">
+           <xs:annotation>
+              <xs:documentation>
+                a file format that is supported for download products.
+              </xs:documentation>
+           </xs:annotation>
+        </xs:element>
+
+        <xs:element name="accessURL" type="imr:AccessURL" minOccurs="0">
+           <xs:annotation>
+              <xs:documentation>
+                 The URL that, when accessed (via HTTP GET), will deliver the 
+                 data or file associated with this resource.  
+              </xs:documentation>
+           </xs:annotation>
+        </xs:element>       
+         
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="AccessURL">
+     <xs:simpleContent>
+       <xs:extension base="xs:anyURI">
+         <xs:attribute name="use">
+           <xs:annotation>
+             <xs:documentation>
+               A flag indicating whether this should be interpreted as a base
+               URL, a full URL, or a URL to a directory that will produce a 
+               listing of files.
+             </xs:documentation>
+             <xs:documentation>
+               The default value assumed when one is not given depends on the 
+               context.  
+             </xs:documentation>
+           </xs:annotation>
+           <xs:simpleType>
+             <xs:restriction base="xs:NMTOKEN">
+               <xs:enumeration value="full">
+                 <xs:annotation>
+                   <xs:documentation>
+                     Assume a full URL--that is, one that can be invoked 
+                     directly without alteration.  This usually returns a 
+                     single document or file.  
+                   </xs:documentation>
+                 </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="base">
+                 <xs:annotation>
+                   <xs:documentation>
+                     Assume a base URL--that is, one requiring an extra portion
+                     to be appended before being invoked.  
+                   </xs:documentation>
+                 </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="dir">
+                 <xs:annotation>
+                   <xs:documentation>
+                     Assume URL points to a directory that will return a listing
+                     of files.  
+                   </xs:documentation>
+                 </xs:annotation>
+               </xs:enumeration>
+             </xs:restriction>
+           </xs:simpleType>
+         </xs:attribute>
+
+         <xs:attribute name="returns" type="xs:token">
+           <xs:annotation>
+             <xs:documentation>
+               a MIME type indicating what is (typically) returned when
+               this URL is retrieved.
+             </xs:documentation>
+             <xs:documentation>
+               If use="dir", returns should usually be set to "text/html" to
+               indicate that the return is a web page listing links to
+               individual components.  
+             </xs:documentation>
+           </xs:annotation>
+         </xs:attribute>
+         
+       </xs:extension>
+     </xs:simpleContent>
+   </xs:complexType>
+
+   <xs:simpleType name="Rights">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="public">
+            <xs:annotation>
+               <xs:documentation>
+                  unrestricted, anonymous access is allowed without 
+                  authentication.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="open-login">
+            <xs:annotation>
+               <xs:documentation>
+                  unrestricted access requires a login (or other 
+                  authentication mechanism).  
+               </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="proprietary">
+            <xs:annotation>
+               <xs:documentation>
+                  requires authentication and users only have access 
+                  to datasets they have been given rights to.  Generally,
+                  there is no charge to use this resource.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="fee-required">
+            <xs:annotation>
+               <xs:documentation>
+                  requires user to pay a one-time or subscription fee in 
+                  order to access the resource.  On-line resources typically
+                  will require authentication.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+
+
 
    <xs:simpleType name="nonemptycontentStringType">
       <xs:annotation>

--- a/schemas/imresource.xsd
+++ b/schemas/imresource.xsd
@@ -1297,34 +1297,122 @@
           </xs:annotation>
         </xs:element>
 
-        <xs:element name="download" type="imr:Download"
-                    minOccurs="0" maxOccurs="1">
+        <xs:element name="via" type="imr:AccessVia"
+                    minOccurs="0" maxOccurs="3">
           <xs:annotation>
             <xs:documentation>
-              a category of property that is sampled by the contained data
+              A description of the access to a resource through some 
+              mechanism.
+            </xs:documentation>
+            <xs:documentation>
+              As the AccessVia type is abstract, all instances must include an
+              xsi:type attribute.
             </xs:documentation>
           </xs:annotation>
         </xs:element>
-         
-        <xs:element name="serviceAPI" type="imr:ServiceAPI"
-                    minOccurs="0" maxOccurs="1">
-          <xs:annotation>
-            <xs:documentation>
-              a category of property that is sampled by the contained data
-            </xs:documentation>
-          </xs:annotation>
-        </xs:element>
-         
-        <xs:element name="media" type="imr:Media"
-                    minOccurs="0" maxOccurs="1">
-          <xs:annotation>
-            <xs:documentation>
-              a category of property that is sampled by the contained data
-            </xs:documentation>
-          </xs:annotation>
-        </xs:element>
-         
+
       </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="AccessVia">
+     <xs:annotation>
+        <xs:documentation>
+          metadata describing how one can access a resource via some mechanism
+        </xs:documentation>
+     </xs:annotation>
+       <xs:sequence>
+
+         <xs:element name="method" type="imr:nonemptycontentStringType">
+            <xs:annotation>
+               <xs:documentation>
+                 A summary of what the service API enables
+               </xs:documentation>
+           </xs:annotation>
+         </xs:element>
+         
+         <xs:element name="description" type="imr:nonemptycontentStringType"
+                     minOccurs="0">
+            <xs:annotation>
+               <xs:documentation>
+                 A summary of how to access the resource by this method.
+               </xs:documentation>
+           </xs:annotation>
+         </xs:element>
+         
+       </xs:sequence>
+   </xs:complexType>
+   
+   <xs:complexType name="_DownloadRestrict" abstract="true">
+      <xs:annotation>
+         <xs:documentation>
+           an AccessVia with method fixed to Download
+         </xs:documentation>
+      </xs:annotation>
+
+      <xs:complexContent>
+        <xs:restriction base="imr:AccessVia">
+          <xs:sequence>
+             <xs:element name="method" type="imr:nonemptycontentStringType"
+                         fixed="download"/>
+             <xs:element name="description" type="imr:nonemptycontentStringType"
+                         minOccurs="0"/>
+          </xs:sequence>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:complexType name="Download">
+     <xs:annotation>
+       <xs:documentation>
+         details on how data can be downloaded
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:complexContent>
+       <xs:extension base="imr:_DownloadRestrict">
+         <xs:sequence>
+
+            <xs:element name="format" type="imr:nonemptycontentStringType"
+                        minOccurs="0">
+               <xs:annotation>
+                  <xs:documentation>
+                    a file format that is supported for download products.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:element>
+
+            <xs:element name="accessURL" type="imr:AccessURL" minOccurs="0">
+               <xs:annotation>
+                  <xs:documentation>
+                     The URL that, when accessed (via HTTP GET), will deliver the 
+                     data or file associated with this resource.  
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:element>       
+         
+         </xs:sequence>
+       </xs:extension>
+     </xs:complexContent>
+
+   </xs:complexType>
+   
+   <xs:complexType name="_ServiceAPIRestrict" abstract="true">
+      <xs:annotation>
+         <xs:documentation>
+           an AccessVia with method fixed to Download
+         </xs:documentation>
+      </xs:annotation>
+
+      <xs:complexContent>
+        <xs:restriction base="imr:AccessVia">
+          <xs:sequence>
+             <xs:element name="method" type="imr:nonemptycontentStringType"
+                         fixed="service API"/>
+             <xs:element name="description" type="imr:nonemptycontentStringType"
+                         minOccurs="0"/>
+          </xs:sequence>
+         </xs:restriction>
+      </xs:complexContent>
    </xs:complexType>
 
    <xs:complexType name="ServiceAPI">
@@ -1334,25 +1422,41 @@
          </xs:documentation>
       </xs:annotation>
 
-      <xs:sequence>
+     <xs:complexContent>
+       <xs:extension base="imr:_ServiceAPIRestrict">
+         <xs:sequence>
 
-        <xs:element name="description" type="xs:token" minOccurs="0">
-           <xs:annotation>
-              <xs:documentation>
-                A summary of what the service API enables
-              </xs:documentation>
-          </xs:annotation>
-        </xs:element>
-         
-        <xs:element name="documentationURL" type="xs:anyURI" minOccurs="0">
-           <xs:annotation>
-              <xs:documentation>
-                The URL to a web page that describes how to use the service.  
-              </xs:documentation>
-          </xs:annotation>
-        </xs:element>
-         
-      </xs:sequence>
+           <xs:element name="documentationURL" type="xs:anyURI" minOccurs="0">
+              <xs:annotation>
+                 <xs:documentation>
+                   The URL to a web page that describes how to use the service.  
+                 </xs:documentation>
+             </xs:annotation>
+           </xs:element>
+            
+         </xs:sequence>
+       </xs:extension>
+     </xs:complexContent>
+
+   </xs:complexType>
+
+   <xs:complexType name="_MediaRestrict" abstract="true">
+      <xs:annotation>
+         <xs:documentation>
+           an AccessVia with method fixed to media
+         </xs:documentation>
+      </xs:annotation>
+
+      <xs:complexContent>
+        <xs:restriction base="imr:AccessVia">
+          <xs:sequence>
+             <xs:element name="method" type="imr:nonemptycontentStringType"
+                         fixed="media"/>
+             <xs:element name="description" type="imr:nonemptycontentStringType"
+                         minOccurs="0"/>
+          </xs:sequence>
+         </xs:restriction>
+      </xs:complexContent>
    </xs:complexType>
 
    <xs:complexType name="Media">
@@ -1362,77 +1466,30 @@
          </xs:documentation>
       </xs:annotation>
 
-      <xs:sequence>
+     <xs:complexContent>
+       <xs:extension base="imr:_MediaRestrict">
+         <xs:sequence>
 
-        <xs:element name="mediaType" type="xs:token"
-                    minOccurs="1" maxOccurs="unbounded">
-           <xs:annotation>
-              <xs:documentation>
-                The type of media provided
-              </xs:documentation>
-          </xs:annotation>
-        </xs:element>
+           <xs:element name="mediaType" type="xs:token"
+                       minOccurs="1" maxOccurs="unbounded">
+              <xs:annotation>
+                 <xs:documentation>
+                   The type of media provided
+                 </xs:documentation>
+             </xs:annotation>
+           </xs:element>
+            
+           <xs:element name="requestURL" type="xs:anyURI" minOccurs="0">
+              <xs:annotation>
+                 <xs:documentation>
+                   The URL to a web page that describes how to use the service.  
+                 </xs:documentation>
+             </xs:annotation>
+           </xs:element>
          
-        <xs:element name="description" type="xs:token" minOccurs="0">
-           <xs:annotation>
-              <xs:documentation>
-                A summary of what the service API enables
-              </xs:documentation>
-          </xs:annotation>
-        </xs:element>
-         
-        <xs:element name="requestURL" type="xs:anyURI" minOccurs="0">
-           <xs:annotation>
-              <xs:documentation>
-                The URL to a web page that describes how to use the service.  
-              </xs:documentation>
-          </xs:annotation>
-        </xs:element>
-         
-      </xs:sequence>
-   </xs:complexType>
-
-   <xs:complexType name="Download">
-      <xs:annotation>
-         <xs:documentation>
-           a container for metrology-specific metadata
-         </xs:documentation>
-      </xs:annotation>
-
-      <xs:sequence>
-
-        <xs:element name="description" type="xs:token" minOccurs="0">
-           <xs:annotation>
-              <xs:documentation>
-                A summary of what the download URL delivers
-              </xs:documentation>
-              <xs:documentation>
-                Providing a description is recommended if more than one
-                portal is available.  If the accessURL's use attribute is set 
-                to "base", describe what is expected to be appended to the URL
-                to retrieve individual files.  
-              </xs:documentation>
-           </xs:annotation>
-        </xs:element>
-
-        <xs:element name="format" type="xs:token" minOccurs="0">
-           <xs:annotation>
-              <xs:documentation>
-                a file format that is supported for download products.
-              </xs:documentation>
-           </xs:annotation>
-        </xs:element>
-
-        <xs:element name="accessURL" type="imr:AccessURL" minOccurs="0">
-           <xs:annotation>
-              <xs:documentation>
-                 The URL that, when accessed (via HTTP GET), will deliver the 
-                 data or file associated with this resource.  
-              </xs:documentation>
-           </xs:annotation>
-        </xs:element>       
-         
-      </xs:sequence>
+         </xs:sequence>
+       </xs:extension>
+     </xs:complexContent>
    </xs:complexType>
 
    <xs:complexType name="AccessURL">

--- a/schemas/nmrr/README.md
+++ b/schemas/nmrr/README.md
@@ -1,0 +1,7 @@
+These are schemas intended for use within the NMRR registry application.  They
+define the internal storage format and are optimized for creating
+human-friendly input forms by default (i.e. using built-in widgets and hint
+support).
+
+
+

--- a/schemas/nmrr/examples/nist-asd.xml
+++ b/schemas/nmrr/examples/nist-asd.xml
@@ -1,18 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <imr:Resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xmlns:imr="http://schema.bipm.org/xml/imres/1.0wd"
-              xmlns:imd="http://schema.bipm.org/xml/imres/data/1.0wd"
-              xsi:type="imd:Database" status="active">
+              xmlns:imr="http://schema.bipm.org/xml/imres/nmrr/database/1.0wd"
+              localid="####.1">
           
    <resourceType>Dataset: Database</resourceType>
 
    <title>NIST Atomic Spectra Database</title>
-   <altTitle type="Subtitle">NIST Standard Reference Database #78</altTitle>
-   <altTitle type="Abbreviation">NIST-ASD</altTitle>
-   <altTitle type="Abbreviation">SRD#78</altTitle>
-   <identifier type="DOI">10.18434/T4W30F</identifier>
-   <homeURL>http://dx.doi.org/10.18434/T4W30F</homeURL>
-   <sponsoringCountry abbrev="USA">United States of America</sponsoringCountry>
+   <subtitle>NIST Standard Reference Database #78</subtitle>
+   <abbreviation>NIST-ASD</abbreviation>
+   <abbreviation>SRD#78</abbreviation>
+   <publisher>US National Institute of Standards and Technology (NIST)</publisher>
+   <sponsoringCountry>
+     <name>United States of America</name>
+     <abbrev>USA</abbrev>
+   </sponsoringCountry>
+   <publicationYear>2014</publicationYear>
+   <homePage xsi:type="imr:DOI">
+     <doi>10.18434/T4W30F</doi>
+   </homePage>
+
+   <contact>
+     <name>Yuri Ralchenko</name>
+     <emailAddress>yuri.ralchenko@nist.gov</emailAddress>
+   </contact>
 
    <creator>
      <name>Alexander Kramida</name>
@@ -47,11 +57,6 @@
      <affiliation>NIST</affiliation>
    </contributor>
 
-   <contact>
-     <name>Yuri Ralchenko</name>
-     <emailAddress>yuri.ralchenko@nist.gov</emailAddress>
-   </contact>
-
    <subject>atomic spectra</subject>
    <subject>spectral lines</subject>
    <subject>energy levels</subject>
@@ -73,9 +78,6 @@
      the ground state. (3) Ground states and ionization energies of
      atoms and atomic ions. 
    </description>
-
-   <publisher>US National Institute of Standards and Technology (NIST)</publisher>
-   <publicationYear> 2014 </publicationYear>
 
    <measures>
      <propertyClass>optical</propertyClass>

--- a/schemas/nmrr/examples/nist-cnv.xml
+++ b/schemas/nmrr/examples/nist-cnv.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<imr:Resource xmlns:imr="http://schema.bipm.org/xml/imres/nmrr/nmi/1.0wd" localid="####">
+  <resourceType>Organization: Metrology Institute</resourceType>
+  <title>US National Institute of Standards and Technology</title>
+  <abbreviation>NIST</abbreviation>
+  <sponsoringCountry>
+    <name>United States of America</name>
+    <abbrev>USA</abbrev>
+  </sponsoringCountry>
+  <homeURL>https://www.nist.gov/</homeURL>
+  <contact>
+    <name>Robert Hanisch</name>
+    <emailAddress>robert.hanisch@nist.gov</emailAddress>
+  </contact>
+  <subject>standards</subject>
+  <subject>standard reference data</subject>
+  <subject>metrology</subject>
+  <subject>materials</subject>
+  <subject>physics</subject>
+  <subject>computing</subject>
+  <subject>cybersecurity</subject>
+  <description>
+     Founded in 1901, NIST is a non-regulatory federal agency within
+     the U.S. Department of Commerce. NIST's mission is to promote
+     U.S. innovation and industrial competitiveness by advancing
+     measurement science, standards, and technology in ways that
+     enhance economic security and improve our quality of life.  NIST
+     carries out its mission through the following programs: (1) the
+     NIST Laboratories, conducting world-class research, often in
+     close collaboration with industry, that advances the nation's
+     technology infrastructure and helps U.S. companies continually
+     improve products and services; (2) the Hollings Manufacturing
+     Extension Partnership, a nationwide network of local centers
+     offering technical and business assistance to smaller
+     manufacturers to help them create and retain jobs, increase
+     profits, and save time and money; and (3) the Baldrige
+     Performance Excellence Program, which promotes performance
+     excellence among U.S. manufacturers, service companies,
+     educational institutions, health care providers, and nonprofit
+     organizations; conducts outreach programs; and manages the annual
+     Malcolm Baldrige National Quality Award which recognizes
+     performance excellence and quality achievement.  It also curates and
+     publishes a number of standard reference and metrology data
+     collections.  
+   </description>
+  <date>1901</date>
+</imr:Resource>

--- a/schemas/nmrr/examples/nist.xml
+++ b/schemas/nmrr/examples/nist.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<imr:Resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns:imr="http://schema.bipm.org/xml/imres/nmrr/nmi/1.0wd"
+              localid="####">
+          
+   <resourceType>Organization: Metrology Institute</resourceType>
+   <title>US National Institute of Standards and Technology</title>
+   <abbreviation>NIST</abbreviation>
+   <sponsoringCountry>
+     <name>United States of America</name>
+     <abbrev>USA</abbrev>
+   </sponsoringCountry>
+   <homeURL>https://www.nist.gov/</homeURL>
+
+   <contact>
+     <name>Robert Hanisch</name>
+     <emailAddress>robert.hanisch@nist.gov</emailAddress>
+   </contact>
+
+   <subject>standards</subject>
+   <subject>standard reference data</subject>
+   <subject>metrology</subject>
+   <subject>materials</subject>
+   <subject>physics</subject>
+   <subject>computing</subject>
+   <subject>cybersecurity</subject>
+
+   <description>
+     Founded in 1901, NIST is a non-regulatory federal agency within
+     the U.S. Department of Commerce. NIST's mission is to promote
+     U.S. innovation and industrial competitiveness by advancing
+     measurement science, standards, and technology in ways that
+     enhance economic security and improve our quality of life.  NIST
+     carries out its mission through the following programs: (1) the
+     NIST Laboratories, conducting world-class research, often in
+     close collaboration with industry, that advances the nation's
+     technology infrastructure and helps U.S. companies continually
+     improve products and services; (2) the Hollings Manufacturing
+     Extension Partnership, a nationwide network of local centers
+     offering technical and business assistance to smaller
+     manufacturers to help them create and retain jobs, increase
+     profits, and save time and money; and (3) the Baldrige
+     Performance Excellence Program, which promotes performance
+     excellence among U.S. manufacturers, service companies,
+     educational institutions, health care providers, and nonprofit
+     organizations; conducts outreach programs; and manages the annual
+     Malcolm Baldrige National Quality Award which recognizes
+     performance excellence and quality achievement.  It also curates and
+     publishes a number of standard reference and metrology data
+     collections.  
+   </description>
+
+   <date>1901</date>
+
+</imr:Resource>

--- a/schemas/nmrr/examples/schemaLocation.txt
+++ b/schemas/nmrr/examples/schemaLocation.txt
@@ -1,3 +1,4 @@
 http://schema.bipm.org/xml/imres/nmrr/nmi/1.0wd ../nmrr-nmi.xsd
+http://schema.bipm.org/xml/imres/nmrr/database/1.0wd ../nmrr-database.xsd
 http://schema.bipm.org/xml/imres/nmrr/org/1.0wd ../imr-organization.xsd
 http://schema.bipm.org/xml/imres/nmrr/gen/1.0wd ../imr-generic.xsd

--- a/schemas/nmrr/examples/schemaLocation.txt
+++ b/schemas/nmrr/examples/schemaLocation.txt
@@ -1,0 +1,3 @@
+http://schema.bipm.org/xml/imres/nmrr/nmi/1.0wd ../nmrr-nmi.xsd
+http://schema.bipm.org/xml/imres/nmrr/org/1.0wd ../imr-organization.xsd
+http://schema.bipm.org/xml/imres/nmrr/gen/1.0wd ../imr-generic.xsd

--- a/schemas/nmrr/imr-organization.xsd
+++ b/schemas/nmrr/imr-organization.xsd
@@ -39,7 +39,7 @@
 
       <xs:sequence>
          <xs:element name="resourceType" type="xs:string"
-                     default="Other: Organization">
+                     default="Organization">
             <xs:annotation>
                <xs:appinfo>
            <label>Resource Type (do not edit)</label>
@@ -93,6 +93,23 @@
                <xs:documentation>
                   an additional identifier that refers to this
                   resource (in another identifier scheme)
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+
+         <xs:element name="sponsoringCountry" minOccurs="0" maxOccurs="unbounded"
+                     type="xs:string">
+            <xs:annotation>
+               <xs:appinfo>
+           <label>Home Country</label>
+           <tooltip>Enter the name of the country where the organization primarily operates and/or serves. </tooltip>
+           <tooltip>Country Name </tooltip>
+                 <am:dcterm>Contributor</am:dcterm>
+                 <am:dataciteproperty>Contributor</am:dataciteproperty>
+               </xs:appinfo>           
+               <xs:documentation>
+                  a country that provided for this resource and/or
+                  which this resource represents.
                </xs:documentation>
             </xs:annotation>
          </xs:element>
@@ -171,7 +188,7 @@
             </xs:annotation>
          </xs:element>
 
-         <xs:element name="referenceURL" type="xs:anyURI">
+         <xs:element name="homeURL" type="xs:anyURI">
             <xs:annotation>
                <xs:appinfo>
                  <label>Organization home page</label>
@@ -218,6 +235,41 @@
         <xs:simpleType xmlns:ns0="http://mdcs.ns" ns0:_mod_mdcs_="/registry/local-id">
           <xs:restriction base="xs:string"/>                      
         </xs:simpleType>
+      </xs:attribute>
+
+      <xs:attribute name="status" use="required">
+         <xs:annotation>
+            <xs:documentation>
+              a tag indicating whether this resource is believed to be still
+              actively maintained.
+            </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:enumeration value="active">
+                 <xs:annotation>
+                   <xs:documentation>
+                      resource is believed to be currently maintained, and its
+                      description is up to date (default). 
+                   </xs:documentation>
+                 </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="inactive">
+                 <xs:annotation>
+                   <xs:documentation>
+                     resource is apparently not being maintained at the present.
+                   </xs:documentation>
+                 </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="deleted">
+                 <xs:annotation>
+                   <xs:documentation>
+                      resource publisher has explicitly deleted the resource.
+                   </xs:documentation>
+                 </xs:annotation>
+               </xs:enumeration>
+            </xs:restriction>
+         </xs:simpleType>
       </xs:attribute>
 
    </xs:complexType>

--- a/schemas/nmrr/nmrr-database.xsd
+++ b/schemas/nmrr/nmrr-database.xsd
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema targetNamespace="http://schema.bipm.org/xml/imres/nmrr/nmi/1.0wd" 
-           xmlns="http://www.w3.org/2001/XMLSchema" 
+<xs:schema targetNamespace="http://schema.bipm.org/xml/imres/nmrr/database/1.0wd" 
            xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-           xmlns:imr="http://schema.bipm.org/xml/imres/nmrr/nmi/1.0wd" 
+           xmlns:imr="http://schema.bipm.org/xml/imres/nmrr/database/1.0wd" 
            xmlns:am="http://schema.nist.gov/xml/nmrr.schema.annot" 
            elementFormDefault="unqualified" 
            attributeFormDefault="unqualified" version="0.1">
@@ -18,10 +17,10 @@
       </xs:documentation>
    </xs:annotation>
 
-   <xs:element name="Resource" type="imr:MetrologyInstitute">
+   <xs:element name="Resource" type="imr:Database">
       <xs:annotation>
          <xs:appinfo>
-           <label>Resource: a Metrology Institute</label>
+           <label>Resource: a Database</label>
          </xs:appinfo>
          <xs:documentation>
            a root element for describing a registered resource 
@@ -29,7 +28,7 @@
       </xs:annotation>
    </xs:element>
 
-   <xs:complexType name="MetrologyInstitute">
+   <xs:complexType name="Database">
       <xs:annotation>
          <xs:documentation>
            a Resource description with resourceType fixed to Other: Organization
@@ -38,11 +37,11 @@
 
       <xs:sequence>
          <xs:element name="resourceType" type="xs:string"
-                     default="Organization: Metrology Institute">
+                     default="Dataset: Database">
             <xs:annotation>
                <xs:appinfo>
            <label>Resource Type (do not edit): </label>
-           <tooltip>This identifies this record as an Organization resource</tooltip>
+           <tooltip>This identifies this record as a Database resource</tooltip>
                  <am:dcterm>Type</am:dcterm>
                  <am:dataciteproperty>resourceType</am:dataciteproperty>
                </xs:appinfo>           
@@ -55,8 +54,8 @@
          <xs:element name="title" type="xs:string">
             <xs:annotation>
                <xs:appinfo>
-                 <label>Institute's Full Name: </label>
-                 <tooltip>The full name given to the organization</tooltip>
+                 <label>Database's Full Name: </label>
+                 <tooltip>The full name given to the database</tooltip>
                  <am:dcterm>Title</am:dcterm>
                  <am:dataciteproperty>Title</am:dataciteproperty>
                </xs:appinfo>           
@@ -66,13 +65,12 @@
             </xs:annotation>
          </xs:element>
 
-         <xs:element name="abbreviation" type="xs:string" minOccurs="0">
+         <xs:element name="subtitle" type="xs:string"
+                     minOccurs="0">
             <xs:annotation>
                <xs:appinfo>
-                 <label>Institution's Abbreviation: </label>
-                 <tooltip>The initials or other abbreviation that the institute is commonly known as</tooltip>
-                 <placeholder>e.g. NIST, BIPM, ...</placeholder>
-                 <use>recommended</use>
+                 <label>Subtitle: </label>
+                 <tooltip>A secondary title for the database (e.g. Standard Reference Data #27)</tooltip>
                  <am:dcterm>Title</am:dcterm>
                  <am:dataciteproperty>Title</am:dataciteproperty>
                </xs:appinfo>           
@@ -82,6 +80,38 @@
             </xs:annotation>
          </xs:element>
 
+         <xs:element name="abbreviation" type="xs:string"
+                     minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:appinfo>
+                 <label>Database's Abbreviation: </label>
+                 <tooltip>The initials, acronym, or other abbreviation that the database is commonly known as</tooltip>
+                 <placeholder>e.g. initials, acronym, etc.</placeholder>
+                 <am:dcterm>Title</am:dcterm>
+                 <am:dataciteproperty>Title</am:dataciteproperty>
+               </xs:appinfo>           
+               <xs:documentation>
+                  An abbreviation the the resource is known as
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+
+         <xs:element name="publisher" type="xs:string">
+            <xs:annotation>
+              <xs:appinfo>
+                <label>Publishing Institution: </label>
+                <tooltip>Enter the name of the metrology institute that provides this database</tooltip>
+                <placholder>Metrology institute name</placholder>
+                 <am:dcterm>Publisher</am:dcterm>
+                 <am:dataciteproperty>publisher</am:dataciteproperty>
+               </xs:appinfo>           
+               <xs:documentation>
+                  Entity (e.g. person or organization) responsible for making 
+                  the resource available.  
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+           
          <xs:element name="sponsoringCountry" minOccurs="0" maxOccurs="unbounded"
                      type="imr:Country">
             <xs:annotation>
@@ -99,15 +129,38 @@
             </xs:annotation>
          </xs:element>
 
-         <xs:element name="homeURL" type="xs:anyURI">
+         <xs:element name="publicationYear" type="xs:string">
             <xs:annotation>
                <xs:appinfo>
-                 <label>Institutes's home page: </label>
-                 <placeholder>http:/...</placeholder>
-               </xs:appinfo>
+                 <label>Publication Year: </label>
+                 <tooltip>The year the database first released.</tooltip>
+                 <placeholder>Format: YYYY</placeholder>
+                 <am:dataciteproperty>publicationYear</am:dataciteproperty>
+               </xs:appinfo>           
                <xs:documentation>
-                  URL pointing to a human-readable document describing this 
-                  resource.   
+                 The year that this resource was made available by the 
+                 publisher.
+               </xs:documentation>
+            </xs:annotation>
+            <!--
+   <xs:simpleType>
+     <xs:restriction base="xs:string">
+        <xs:pattern value="[\d]{4}"/>
+     </xs:restriction>
+   </xs:simpleType>
+-->
+         </xs:element>
+
+         <xs:element name="homePage" type="imr:IDorURL" minOccurs="1">
+            <xs:annotation>
+               <xs:appinfo>
+                 <label>Primary Identifier or Location: </label>
+                 <am:dcterm>identifier</am:dcterm>
+                 <am:dataciteproperty>identifier</am:dataciteproperty>
+               </xs:appinfo>           
+               <xs:documentation>
+                  an unambiguous, globally-unique identifier for this 
+                  resource description.
                </xs:documentation>
             </xs:annotation>
          </xs:element>
@@ -121,12 +174,40 @@
             </xs:annotation>
          </xs:element>
 
+         <xs:element name="creator" type="imr:Entity"
+                     minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:appinfo>
+                 <am:dcterm>Creator</am:dcterm>
+                 <am:dataciteproperty>creator</am:dataciteproperty>
+               </xs:appinfo>           
+               <xs:documentation>
+                 The entity (e.g. person or organization) primarily responsible 
+                 for creating the content or constitution of the resource.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+
+         <xs:element name="contributor" type="imr:Contributor" 
+                     minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:appinfo>
+                 <am:dcterm>Contributor</am:dcterm>
+                 <am:dataciteproperty>contributor</am:dataciteproperty>
+               </xs:appinfo>
+               <xs:documentation>
+                 Entity responsible for contributions made to the development of
+                 the resource
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+
          <xs:element name="subject" type="xs:string" maxOccurs="unbounded">
             <xs:annotation>
                <xs:appinfo>
                  <label>Subject keyword: </label>
                  <placeholder>Enter a descriptive term; click the + to add additional keywords</placeholder>
-                 <tooltip>a descriptive term related to activities of this institute.</tooltip>
+                 <tooltip>a descriptive term that this database relates to.  Choose terms that describe what measurements this database includes.</tooltip>
                  <am:dcterm>Subject</am:dcterm>
                </xs:appinfo>           
                <xs:documentation>
@@ -139,7 +220,7 @@
          <xs:element name="description" type="xs:token" maxOccurs="unbounded" xmlns:ns0="http://mdcs.ns" ns0:_mod_mdcs_="/registry/description">
             <xs:annotation>
                <xs:appinfo>
-                 <label>Give a summary of the purpose and activity of the organization: </label>
+                 <label>Give a summary of the contents of the database and how users may access it: </label>
                  <am:dcterm>Description</am:dcterm>
                  <am:datacite>description</am:datacite>
                </xs:appinfo>           
@@ -159,27 +240,31 @@
             </xs:annotation>
          </xs:element>
 
-         <xs:element name="date" 
-                     minOccurs="0" maxOccurs="1">
-            <xs:annotation>
+           <xs:element name="measures" type="imr:Measures" minOccurs="0">
+              <xs:annotation>
                <xs:appinfo>
-                 <label>Year Established: </label>
-                 <tooltip>Enter the year the institute was established</tooltip>
-                 <placeholder>Format: YYYY</placeholder>
-                 <am:dcterm>Date</am:dcterm>
+                 <label>Metrology Information</label>
+               </xs:appinfo>
+                 <xs:documentation>
+                   Information describing the variety of measurements 
+                   available in this data
+                 </xs:documentation>
+              </xs:annotation>
+           </xs:element>
+
+           <xs:element name="access" type="imr:Access">
+             <xs:annotation>
+               <xs:appinfo>
+                 <label>Access Information</label>
                </xs:appinfo>
                <xs:documentation>
-                 Date associated with an event in the life cycle of the
-                 resource.  
+                 Information describing how to access the resource and its 
+                 features and capabilities.  
                </xs:documentation>
-            </xs:annotation>
-   <xs:simpleType>
-     <xs:restriction base="xs:string">
-        <xs:pattern value="[\d]{4}"/>
-     </xs:restriction>
-   </xs:simpleType>
+             </xs:annotation>
+           </xs:element>
 
-         </xs:element>
+
 
          
 
@@ -314,28 +399,42 @@
       <xs:sequence>
          <xs:element name="name" type="xs:string">
             <xs:annotation>
+               <xs:appinfo>
+                 <label>Name: </label>
+                 <tooltip>The name of a person or group</tooltip>
+               </xs:appinfo>
                <xs:documentation>
                   The person or entity's displayable name
                </xs:documentation>
             </xs:annotation>
          </xs:element>
          
-         <xs:element name="identifier" type="imr:EntityID" minOccurs="0">
-            <xs:annotation>
-               <xs:documentation>
-                  The person or entity's identifier
-               </xs:documentation>
-            </xs:annotation>
-         </xs:element>
-
          <xs:element name="affiliation" minOccurs="0" maxOccurs="unbounded">
             <xs:annotation>
+               <xs:appinfo>
+                 <label>Institutional affiliation: </label>
+                 <tooltip>Add if different from the database's publisher</tooltip>
+               </xs:appinfo>
                <xs:documentation>
                   The person or entity's institutional affiliation at
                   the time their contribution was made
                </xs:documentation>
             </xs:annotation>
          </xs:element>
+
+         <xs:element name="identifier" type="xs:string" minOccurs="0">
+            <xs:annotation>
+               <xs:appinfo>
+                 <label>ORCID identifier: http://orcid.org/</label>
+                 <placeholder>Format: xxxx-xxxx-xxxx-xxxx</placeholder>
+                 <tooltip>Add if different from the database's publisher</tooltip>
+               </xs:appinfo>
+               <xs:documentation>
+                  The person or entity's identifier
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+
       </xs:sequence>
    </xs:complexType>
    
@@ -951,7 +1050,450 @@
      </xs:restriction>
    </xs:simpleType>
 
+   <xs:complexType name="Measures">
+      <xs:annotation>
+         <xs:documentation>
+           a container for metrology-specific metadata
+         </xs:documentation>
+      </xs:annotation>
+
+      <xs:sequence>
+
+        <xs:element name="propertyClass" type="imr:PropertyClass"
+                    minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:appinfo>
+                 <label>Class of properties measured: </label>
+               </xs:appinfo>
+               <xs:documentation>
+                  a category of property that is sampled by the contained data
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         
+         <xs:element name="substance" type="xs:string"
+                     minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:appinfo>
+                 <label>Substance (or constituent) sampled or addressed: </label>
+                 <tooltip>Provide </tooltip>
+               </xs:appinfo>
+               <xs:documentation>
+                 a substance or substance constituent that was sampled,
+                 measured, or addressed in this data.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:simpleType name="PropertyClass">
+     <xs:annotation>
+       <xs:documentation>
+         allowed values representing categories of material physical properties
+       </xs:documentation>
+     </xs:annotation>
+     <xs:restriction base="xs:token">
+       <xs:enumeration value="optical">
+         <xs:annotation>
+           <xs:documentation>
+             property describes out a material interacts with electromagnetic 
+             radiation.
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="mechanical">
+         <xs:annotation>
+           <xs:documentation>
+             property describes a sample material's response to an external 
+             influence causing plastic deformation or destruction.
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="thermal">
+         <xs:annotation>
+           <xs:documentation>
+             property describing a materials response to heat, including the 
+             transfer of heat through the material and thermophysical properties
+             (those that vary with temperature without changing the material's 
+             identity. 
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="structural">
+         <xs:annotation>
+           <xs:documentation>
+             properties describing the relative locations of a material's 
+             constituent atoms or molecules. 
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="simulated">
+         <xs:annotation>
+           <xs:documentation>
+             a property or parameter describing a material's state as calculated
+             in a computational simulation.
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="transport">
+         <xs:annotation>
+           <xs:documentation>
+             a property describing the transport of mass through a material.
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="deteriorative">
+         <xs:annotation>
+           <xs:documentation>
+             a property related to material deterioration
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="chemical">
+         <xs:annotation>
+           <xs:documentation>
+             a property describing the chemical behavior or structure, including
+             related to its electronic states.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+     </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="Access">
+      <xs:annotation>
+         <xs:documentation>
+           a container for metrology-specific metadata
+         </xs:documentation>
+      </xs:annotation>
+
+      <xs:sequence>
+
+        <xs:element name="rights" type="imr:Rights"
+                    minOccurs="1" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <label>Availability: </label>
+              <am:dcterm>Rights</am:dcterm>
+            </xs:appinfo>           
+            <xs:documentation>
+              Information about the held in and over the resource.
+            </xs:documentation>
+            <xs:documentation>
+              This should be repeated for all Rights values that apply.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+
+        <xs:element name="licenseName" type="xs:token" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <label>License Name: </label>
+              <placeholder>e.g. Creative Commons BY-NC, public domain</placeholder>
+              <tooltip>Name of license that allows use of this data.  If this is a community license (e.g. Creative Commons), then give its name here.</tooltip>
+              <am:dcterm>License</am:dcterm>
+            </xs:appinfo>           
+            <xs:documentation>
+              The common name for the license that covers access to this
+              data resource.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        
+        <xs:element name="termsURL" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:appinfo>
+              <label>URL for Terms of Use: </label>
+              <placeholder>http://...</placeholder>
+              <tooltip>URL that provides full statement of the license or terms of use.</tooltip>
+              <am:dcterm>Rights</am:dcterm>
+            </xs:appinfo>           
+            <xs:documentation>
+              A public URL to a document describing the terms of access
+              for the resource.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+
+        <xs:element name="via" type="imr:AccessVia"
+                    minOccurs="0" maxOccurs="3">
+          <xs:annotation>
+            <xs:appinfo>
+              <label>Available data access method: </label>
+              <am:dcterm>Rights</am:dcterm>
+            </xs:appinfo>           
+            <xs:documentation>
+              A description of the access to a resource through some 
+              mechanism.
+            </xs:documentation>
+            <xs:documentation>
+              As the AccessVia type is abstract, all instances must include an
+              xsi:type attribute.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="AccessVia">
+     <xs:annotation>
+        <xs:documentation>
+          metadata describing how one can access a resource via some mechanism
+        </xs:documentation>
+     </xs:annotation>
+       <xs:sequence>
+
+         
+       </xs:sequence>
+   </xs:complexType>
    
+   <xs:complexType name="Download">
+     <xs:annotation>
+       <xs:documentation>
+         details on how data can be downloaded
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:complexContent>
+       <xs:extension base="imr:AccessVia">
+         <xs:sequence>
+
+            <xs:element name="format" type="xs:string"
+                        minOccurs="0">
+              <xs:annotation>
+                <xs:appinfo>
+                  <label>Supported download format: </label>
+                  <tooltip>Name of file format available for download</tooltip>
+                </xs:appinfo>
+                  <xs:documentation>
+                    a file format that is supported for download products.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:element>
+
+            <xs:element name="accessURL" type="xs:anyURI" minOccurs="0">
+               <xs:annotation>
+             <xs:appinfo>
+               <label>Download URL: </label>
+             </xs:appinfo>           
+                  <xs:documentation>
+                     The URL that, when accessed (via HTTP GET), will deliver the 
+                     data or file associated with this resource.  
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:element>       
+         
+            <xs:element name="description" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:appinfo>
+                  <label>Comments: </label>
+                  <tooltip>Add any useful comments about what is available for download.</tooltip>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+            
+         </xs:sequence>
+       </xs:extension>
+     </xs:complexContent>
+
+   </xs:complexType>
+   
+   <xs:complexType name="ServiceAPI">
+      <xs:annotation>
+         <xs:documentation>
+           a container for information on accessing the data via a service API
+         </xs:documentation>
+      </xs:annotation>
+
+     <xs:complexContent>
+       <xs:extension base="imr:AccessVia">
+         <xs:sequence>
+
+            <xs:element name="description" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:appinfo>
+                  <label>Summary: </label>
+                  <tooltip>Enter a brief summary of what the API provides.</tooltip>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+            
+           <xs:element name="documentationURL" type="xs:anyURI" minOccurs="0">
+              <xs:annotation>
+                <xs:appinfo>
+                  <label>URL to service documentation: </label>
+                  <tooltip>Enter a URL of a human-readable description of how to use the service.</tooltip>
+                  <placeholder>http://...</placeholder>
+                </xs:appinfo>
+                 <xs:documentation>
+                   The URL to a web page that describes how to use the service.  
+                 </xs:documentation>
+             </xs:annotation>
+           </xs:element>
+         </xs:sequence>
+       </xs:extension>
+     </xs:complexContent>
+
+   </xs:complexType>
+
+   <xs:complexType name="Media">
+      <xs:annotation>
+         <xs:documentation>
+           a container for information on accessing the data via a service API
+         </xs:documentation>
+      </xs:annotation>
+
+     <xs:complexContent>
+       <xs:extension base="imr:AccessVia">
+         <xs:sequence>
+
+           <xs:element name="mediaType" type="imr:MediaTypeNames"
+                       minOccurs="1" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:appinfo>
+                  <label>Type of media available: </label>
+                </xs:appinfo>
+                 <xs:documentation>
+                   The type of media provided
+                 </xs:documentation>
+             </xs:annotation>
+           </xs:element>
+            
+           <xs:element name="requestURL" type="xs:anyURI" minOccurs="0">
+              <xs:annotation>
+                <xs:appinfo>
+                  <label>Media request URL: </label>
+                  <placeholder>http://...</placeholder>
+                  <tooltip>URL where media containing data can be requested or ordered.</tooltip>
+                </xs:appinfo>
+                 <xs:documentation>
+                   The URL to a web page that describes how to request the data on various media.
+                 </xs:documentation>
+             </xs:annotation>
+           </xs:element>
+            
+            <xs:element name="description" type="xs:string"
+                         minOccurs="0">
+              <xs:annotation>
+                <xs:appinfo>
+                  <label>Comments: </label>
+                  <tooltip>Add any useful comments about how to order media or what is available.</tooltip>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+         
+         </xs:sequence>
+       </xs:extension>
+     </xs:complexContent>
+   </xs:complexType>
+
+   <xs:complexType name="AccessURL">
+     <xs:sequence>
+        <xs:element name="URL" type="xs:anyURI"
+                    minOccurs="1" maxOccurs="unbounded">
+           <xs:annotation>
+             <xs:appinfo>
+               <label>Download URL: </label>
+             </xs:appinfo>           
+           </xs:annotation>
+        </xs:element>
+
+        <xs:element name="use" type="xs:string">
+           <xs:annotation>
+             <xs:appinfo>
+               <label>which points to a... </label>
+             </xs:appinfo>           
+           </xs:annotation>
+        </xs:element>
+        
+     </xs:sequence>
+
+   </xs:complexType>
+
+   <xs:simpleType name="Rights">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="public">
+            <xs:annotation>
+               <xs:documentation>
+                  unrestricted, anonymous access is allowed without 
+                  authentication.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="open-login">
+            <xs:annotation>
+               <xs:documentation>
+                  unrestricted access requires a login (or other 
+                  authentication mechanism).  
+               </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="proprietary">
+            <xs:annotation>
+               <xs:documentation>
+                  requires authentication and users only have access 
+                  to datasets they have been given rights to.  Generally,
+                  there is no charge to use this resource.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="fee-required">
+            <xs:annotation>
+               <xs:documentation>
+                  requires user to pay a one-time or subscription fee in 
+                  order to access the resource.  On-line resources typically
+                  will require authentication.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+
+
+   <xs:simpleType name="MediaTypeNames">
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="CD/CDROM">
+            <xs:annotation>
+               <xs:documentation>
+               </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DVD/DVDROM">
+            <xs:annotation>
+               <xs:documentation>
+               </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="flash drive">
+            <xs:annotation>
+               <xs:documentation>
+               </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="floppy disc">
+            <xs:annotation>
+               <xs:documentation>
+               </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="other">
+            <xs:annotation>
+               <xs:documentation>
+               </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
 
    <xs:simpleType name="nonemptycontentStringType">
       <xs:annotation>
@@ -964,6 +1506,49 @@
          <xs:minLength value="1"/>
       </xs:restriction>
    </xs:simpleType>
+
+   <xs:complexType name="IDorURL" abstract="true">
+     <xs:sequence>
+     </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="DOI">
+     <xs:complexContent>
+       <xs:extension base="imr:IDorURL">
+         <xs:sequence>
+           <xs:element name="doi" type="xs:string">
+             <xs:annotation>
+                <xs:appinfo>
+                  <label>Digital Object Identifier (DOI): http://dx.doi.org/</label>
+                  <placeholder>10....</placeholder>
+                  <tooltip>the DOI starting with its numeric prefix (e.g. "10.")</tooltip>
+                </xs:appinfo>
+             </xs:annotation>
+           </xs:element>
+         </xs:sequence>
+       </xs:extension>
+     </xs:complexContent>
+   </xs:complexType>
+
+   <xs:complexType name="HomePageURL">
+     <xs:complexContent>
+       <xs:extension base="imr:IDorURL">
+         <xs:sequence>
+           <xs:element name="url" type="xs:string">
+             <xs:annotation>
+                <xs:appinfo>
+                  <label>Database home page URL: </label>
+                  <placeholder>http://...</placeholder>
+                  <tooltip>the primary URL where the database can be accessed.</tooltip>
+                </xs:appinfo>
+             </xs:annotation>
+           </xs:element>
+         </xs:sequence>
+       </xs:extension>
+     </xs:complexContent>
+   </xs:complexType>
+
+   
 
 </xs:schema>
 

--- a/schemas/nmrr/nmrr-database.xsd
+++ b/schemas/nmrr/nmrr-database.xsd
@@ -1194,7 +1194,7 @@
           </xs:annotation>
         </xs:element>
 
-        <xs:element name="licenseName" type="xs:token" minOccurs="0">
+        <xs:element name="licenseName" type="xs:string" minOccurs="0">
           <xs:annotation>
             <xs:appinfo>
               <label>License Name: </label>

--- a/schemas/nmrr/nmrr-nmi.xsd
+++ b/schemas/nmrr/nmrr-nmi.xsd
@@ -1,0 +1,969 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://schema.bipm.org/xml/imres/nmrr/nmi/1.0wd" 
+           xmlns="http://www.w3.org/2001/XMLSchema" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns:imr="http://schema.bipm.org/xml/imres/nmrr/nmi/1.0wd" 
+           xmlns:am="http://schema.nist.gov/xml/nmrr.schema.annot" 
+           elementFormDefault="unqualified" 
+           attributeFormDefault="unqualified" version="0.1">
+
+   <xs:annotation>
+      <xs:documentation>
+        An IMRR metadata extension to define the Organization resource type.
+      </xs:documentation>
+      <xs:documentation>
+        This schema draws on concepts and patterns used in the
+        DataCite metadata Schema for the Publication and Citation
+        of Research Data (https://schema.datacite.org/meta/kernel-3/).
+      </xs:documentation>
+   </xs:annotation>
+
+   <xs:element name="Resource" type="imr:MetrologyInstitute">
+      <xs:annotation>
+         <xs:appinfo>
+           <label>Resource: a Metrology Institute</label>
+         </xs:appinfo>
+         <xs:documentation>
+           a root element for describing a registered resource 
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="MetrologyInstitute">
+      <xs:annotation>
+         <xs:documentation>
+           a Resource description with resourceType fixed to Other: Organization
+         </xs:documentation>
+      </xs:annotation>
+
+      <xs:sequence>
+         <xs:element name="resourceType" type="xs:string"
+                     default="Organization: Metrology Institute">
+            <xs:annotation>
+               <xs:appinfo>
+           <label>Resource Type (do not edit): </label>
+           <tooltip>This identifies this record as an Organization resource</tooltip>
+                 <am:dcterm>Type</am:dcterm>
+                 <am:dataciteproperty>resourceType</am:dataciteproperty>
+               </xs:appinfo>           
+               <xs:documentation>
+                  a label that indicates the kind of resource it is.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+
+         <xs:element name="title" type="xs:string">
+            <xs:annotation>
+               <xs:appinfo>
+                 <label>Institute's Full Name: </label>
+                 <tooltip>The full name given to the organization</tooltip>
+                 <am:dcterm>Title</am:dcterm>
+                 <am:dataciteproperty>Title</am:dataciteproperty>
+               </xs:appinfo>           
+               <xs:documentation>
+                  the full name given to the resource
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+
+         <xs:element name="abbreviation" type="xs:string" minOccurs="0">
+            <xs:annotation>
+               <xs:appinfo>
+                 <label>Institution's Abbreviation: </label>
+                 <tooltip>The initials or other abbreviation that the institute is commonly known as</tooltip>
+                 <placeholder>e.g. NIST, BIPM, ...</placeholder>
+                 <use>recommended</use>
+                 <am:dcterm>Title</am:dcterm>
+                 <am:dataciteproperty>Title</am:dataciteproperty>
+               </xs:appinfo>           
+               <xs:documentation>
+                  An abbreviation the the resource is known as
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+
+         <xs:element name="sponsoringCountry" minOccurs="0" maxOccurs="unbounded"
+                     type="imr:Country">
+            <xs:annotation>
+               <xs:appinfo>
+           <label>Home Country: </label>
+           <tooltip>Enter the name of the country where the NMI primarily operates and/or serves. </tooltip>
+           <tooltip>Country Name </tooltip>
+                 <am:dcterm>Contributor</am:dcterm>
+                 <am:dataciteproperty>Contributor</am:dataciteproperty>
+               </xs:appinfo>           
+               <xs:documentation>
+                  a country that provided for this resource and/or
+                  which this resource represents.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+
+         <xs:element name="homeURL" type="xs:anyURI">
+            <xs:annotation>
+               <xs:appinfo>
+                 <label>Institutes's home page: </label>
+                 <placeholder>http:/...</placeholder>
+               </xs:appinfo>
+               <xs:documentation>
+                  URL pointing to a human-readable document describing this 
+                  resource.   
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+
+         <xs:element name="contact" type="imr:Contact" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:documentation>
+                 Information that can be used for contacting someone with
+                 regard to this resource.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+
+         <xs:element name="subject" type="xs:string" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:appinfo>
+                 <label>Subject keyword: </label>
+                 <placeholder>Enter a descriptive term; click the + to add additional keywords</placeholder>
+                 <tooltip>a descriptive term related to activities of this institute.</tooltip>
+                 <am:dcterm>Subject</am:dcterm>
+               </xs:appinfo>           
+               <xs:documentation>
+                 a topic, object type, or other descriptive keywords 
+                 about the resource.  
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+
+         <xs:element name="description" type="xs:token" maxOccurs="unbounded" xmlns:ns0="http://mdcs.ns" ns0:_mod_mdcs_="/registry/description">
+            <xs:annotation>
+               <xs:appinfo>
+                 <label>Give a summary of the purpose and activity of the organization: </label>
+                 <am:dcterm>Description</am:dcterm>
+                 <am:datacite>description</am:datacite>
+               </xs:appinfo>           
+               <xs:documentation>
+                 An account of the nature of the resource
+               </xs:documentation>
+               <xs:documentation>
+                 The description may include but is not limited to an abstract, 
+                 table of contents, reference to a graphical representation of
+                 content or a free-text account of the content.
+               </xs:documentation>
+               <xs:documentation>
+                 Each description element represents a separate paragraph; thus,
+                 order is significant (i.e. the first occurance is the first
+                 paragraph).  The first occurance should give an overall summary.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+
+         <xs:element name="date" 
+                     minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+               <xs:appinfo>
+                 <label>Year Established: </label>
+                 <tooltip>Enter the year the institute was established</tooltip>
+                 <placeholder>Format: YYYY</placeholder>
+                 <am:dcterm>Date</am:dcterm>
+               </xs:appinfo>
+               <xs:documentation>
+                 Date associated with an event in the life cycle of the
+                 resource.  
+               </xs:documentation>
+            </xs:annotation>
+   <xs:simpleType>
+     <xs:restriction base="xs:string">
+        <xs:pattern value="[\d]{4}"/>
+     </xs:restriction>
+   </xs:simpleType>
+
+         </xs:element>
+
+         
+
+      </xs:sequence>
+
+      <xs:attribute name="localid">
+        <xs:annotation>
+          <xs:appinfo>
+            <label>Local ID (do not change)</label>
+          </xs:appinfo>
+          <xs:documentation>
+            An unambiguous identifier for this resource description as 
+            assigned by its author or its curating registry.  
+          </xs:documentation>
+          <xs:documentation>
+            This attribute is required on export.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType xmlns:ns0="http://mdcs.ns" ns0:_mod_mdcs_="/registry/local-id">
+          <xs:restriction base="xs:string"/>                      
+        </xs:simpleType>
+      </xs:attribute>
+
+   </xs:complexType>
+
+   <xs:complexType name="AltTitle">
+      <xs:annotation>
+         <xs:documentation>
+           A name or title by which a resource is known.
+         </xs:documentation>
+      </xs:annotation>
+
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+ 	    <xs:attribute name="type" type="imr:TitleType" use="required">
+               <xs:annotation>
+                  <xs:documentation>
+                    The type of title; either "AlternativeTitle",
+                    "Subtitle", or "TranslatedTitle"
+                  </xs:documentation>
+                  <xs:documentation>
+                    Use xml:lang if type is "TranslatedTitle"
+                  </xs:documentation>
+               </xs:annotation>
+ 	    </xs:attribute>      
+
+<!--
+            <xs:attribute ref="xml:lang" use="optional"/>
+  -->
+         </xs:extension>
+      </xs:simpleContent>
+
+   </xs:complexType>
+
+   <xs:simpleType name="TitleType">
+     <xs:annotation>
+       <xs:documentation>
+         Allowed values for the AltTitle's type attribute
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:restriction base="xs:string">
+       <xs:enumeration value="AlternativeTitle">
+         <xs:annotation>
+           <xs:documentation>
+             title value represents an alternate or often used title for the
+             resource, but which is not its official or preferred title.
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Subtitle">
+         <xs:annotation>
+           <xs:documentation>
+             title value represents a secondary or subtitle for the resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="TranslatedTitle">
+         <xs:annotation>
+           <xs:documentation>
+             title value represents a title in an alternate language as given
+             by the xml:lang attribute.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+         
+     </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="Country">
+      <xs:annotation>
+         <xs:documentation>
+           A country's name
+         </xs:documentation>
+      </xs:annotation>
+
+      <xs:sequence>
+         <xs:element name="name" type="xs:string">
+            <xs:annotation>
+               <xs:appinfo>
+                 <label>Country's Full name: </label>
+               </xs:appinfo>
+               <xs:documentation>
+                  The person or entity's displayable name
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         
+         <xs:element name="abbrev" type="xs:string" minOccurs="0">
+            <xs:annotation>
+               <xs:appinfo>
+                 <label>Abbreviation: </label>
+                 <use>recommended</use>
+                 <placeholder>e.g. USA, UK, South Korea, ...</placeholder>
+               </xs:appinfo>
+            </xs:annotation>
+         </xs:element>
+         
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="Entity">
+      <xs:annotation>
+        <xs:documentation>
+          a person or other entity (e.g. team or people) responsible
+          for something.
+        </xs:documentation>
+      </xs:annotation>
+
+      <xs:sequence>
+         <xs:element name="name" type="xs:string">
+            <xs:annotation>
+               <xs:documentation>
+                  The person or entity's displayable name
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         
+         <xs:element name="identifier" type="imr:EntityID" minOccurs="0">
+            <xs:annotation>
+               <xs:documentation>
+                  The person or entity's identifier
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+
+         <xs:element name="affiliation" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:documentation>
+                  The person or entity's institutional affiliation at
+                  the time their contribution was made
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   
+   <xs:complexType name="EntityID">
+      <xs:annotation>
+        <xs:documentation>
+          an identifier identifying a person, organization, or other entity
+        </xs:documentation>
+      </xs:annotation>
+
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="identifierScheme" use="required"/>
+            <xs:attribute name="schemeURI" type="xs:anyURI" use="optional"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <xs:complexType name="Contact">
+      <xs:annotation>
+        <xs:documentation>
+          information that can be used to contact someone
+        </xs:documentation>
+      </xs:annotation>
+
+      <xs:sequence>
+         <xs:element name="name" type="xs:string">
+            <xs:annotation>
+               <xs:documentation>
+                  The person or entity's displayable name
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         
+         <xs:element name="emailAddress" type="xs:string"
+                     minOccurs="1" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:documentation>the contact email address</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   
+   <xs:complexType name="Contributor">
+     <xs:annotation>
+       <xs:documentation>
+         a contributor that plays one of the roles defined by the
+         datacite metadata schema.  
+       </xs:documentation>
+     </xs:annotation>
+
+      <xs:sequence>
+         <xs:element name="name" type="xs:token">
+            <xs:annotation>
+               <xs:documentation>
+                  The person or entity's displayable name
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         
+         <xs:element name="identifier" type="imr:EntityID" minOccurs="0">
+            <xs:annotation>
+               <xs:documentation>
+                  The person or entity's identifier
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+
+         <xs:element name="affiliation" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:documentation>
+                  The person or entity's institutional affiliation at
+                  the time their contribution was made
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+
+          <xs:attribute name="type" type="imr:ContributorType" use="required">
+            <xs:annotation>
+              <xs:documentation>
+                a label indicating the contribution that this person
+                or organization made to the resource.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+
+   </xs:complexType>
+
+   <xs:simpleType name="ContributorType">
+     <xs:annotation>
+       <xs:appinfo>
+         <am:dataciteproperty>ContributorType</am:dataciteproperty>
+       </xs:appinfo>
+       <xs:documentation>
+         Controlled labels that indicate the type of contribution
+         made which correspond to those defined by the Datacite
+         Metadata schema (v3.1)
+       </xs:documentation>
+       <xs:documentation>
+         Note that ContactPerson is not defined; the &lt;contact&gt; element
+         should be used instead.  
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:restriction base="xs:string">
+
+       <xs:enumeration value="DataCollector">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>DataCollector</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person or institution responsible for
+             finding, gathering/collecting data under the guidelines
+             of the author(s) or principal investigator.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="DataCurator">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>DataCurator</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person or institution tasked with reviewing,
+             enhancing, cleaning, or standardizing metadata and the
+             associated data submitted for storage, use, and
+             mainteneance witin a data cetner or repository
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="DataManager">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>DataManager</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person or organization responsible for maintaining
+             the finished resource 
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Distributor">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Distributor</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the institution tasked with responsibility to
+             generate/disseminate copies of the resource in either electronic
+             or print form.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Editor">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Editor</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person who oversees the details related to the
+             publication format of the resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Funder">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Funder</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating an institution that provided financial support for the
+             development of the resource 
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="HostingInstitution">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>HostingInstitution</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the organization allowing the resource to be available
+             on the internet through the provision of its
+             hardware/software/operating support
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Producer">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Producer</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person or organization responsible for the artistry
+             and form of a media product
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="ProjectLeader">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>ProjectLeader</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person officially designated as head of a project
+             team instrumental in the work necessary to the development of
+             the resource 
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="ProjectManager">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>ProjectManager</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person officially designated as manager of a project
+             which was instrumental in the work necessary to the development of
+             the resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="ProjectMember">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>ProjectMember</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person on the membership list of a designated project
+             or project team which was instrumental in the work necessary to
+             the development of the resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="RegistrationAgency">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>RegistrationAgency</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating an institution/organization officially appointed by
+             a registration authority to handle specific tasks within a
+             defined area of responsibility
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="RegistrationAuthority">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>RegistrationAuthority</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a standards-setting body from which registration
+             agencies obtain official recognition and guidance
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="RelatedPerson">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>RelatedPerson</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person without a specifically defined role in the
+             development of the resource, but who is someone a creator wishes
+             to recognize.
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Researcher">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Researcher</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person involved in analyzing data or the results of
+             an experiment or formal study.
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="ResearchGroup">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>ResearchGroup</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a group of individuals with a lab, department, or
+             division with a particular, defined focus of activity
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="RightsHolder">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>RightsHolder</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person or institution owning or managing property
+             rights, including intellectual property rights, over the resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Sponsor">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Sponsor</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person or organization that issued a contract or
+             under the auspices of which a work has been written, printed,
+             published, developed, etc. 
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Supervisor">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Supervisor</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a designated administrator over one or more groups/teams
+             working to produce the resource or over one or more streps of the 
+             development process
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="WorkPackageLeader">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>WorkPackageLeader</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person responsible for ensuring the comprehensive
+             contents, versioning, and availability of a work package (i.e.
+             a recognized data product, not all of which may be included in the
+             resource) during the development of the resource.
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Other">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Other</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person or organization making a significant
+             contribution to the development and/or maintenance of the
+             resource, but whose contribution does not fit the definitions
+             of the other defined contributor types.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+     </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="Subject">
+     <xs:annotation>
+       <xs:documentation>
+         a type for expressing a subject keyword that may be drawn from
+         a standard set of keywords
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:simpleContent>
+       <xs:extension base="xs:token">
+         <xs:attribute name="scheme" use="optional" type="xs:string">
+           <xs:annotation>
+             <xs:documentation>
+               a label or classification code indicating the vocabulary that
+               this subject keyword was drawn from
+             </xs:documentation>
+           </xs:annotation>
+         </xs:attribute>
+
+         <xs:attribute name="schemeURI" use="optional" type="xs:anyURI">
+           <xs:annotation>
+             <xs:documentation>
+               The URI identifying or describing the vocabulary that
+               the subject keyword was drawn from
+             </xs:documentation>
+           </xs:annotation>
+         </xs:attribute>
+
+         <xs:attribute name="pid" use="optional" type="xs:anyURI">
+           <xs:annotation>
+             <xs:appinfo>
+             <label>Subject URI (optional)</label>
+             <placeholder>http://...</placeholder>
+             <tooltip>If one is known, enter the URI that unambiguously identifies this subject.</tooltip>
+             </xs:appinfo>
+             <xs:documentation>
+               The machine-recognizable URI identifying the specific subject 
+               keyword.
+             </xs:documentation>
+             <xs:documentation>
+               Use this attribute if the keyword corresponds to a subject from
+               an RDF vocabulary.
+             </xs:documentation>
+           </xs:annotation>
+         </xs:attribute>
+
+       </xs:extension>
+     </xs:simpleContent>
+
+   </xs:complexType>
+
+   <xs:simpleType name="Year">
+     <xs:annotation>
+       <xs:documentation>
+         An A.D. year date with format YYYY.
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:restriction base="xs:string">
+        <xs:pattern value="[\d]{4}"/>
+     </xs:restriction>
+   </xs:simpleType>
+
+   <xs:simpleType name="NoTimeDate">
+     <xs:annotation>
+       <xs:documentation>
+         A restricted format for expressing dates compliant with the Datacite
+         date formatting recommendations.  The value is either a single year,
+         month, or day value (compliant with the W3C Note on data formats,
+         http://www.w3.org/TR/NOTE-datetime), or two such values delimited by
+         a slash, indicating a range of values.
+       </xs:documentation>
+       <xs:documentation>
+         Single values are restricted to the following forms:  YYYY, YYYY-MM,
+         or YYYY-MM-DD.  
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:restriction base="xs:token">
+       <xs:pattern value="\d{4}(-\d{2}(-\d{2}(/\d{4}(-\d{2}(-\d{2})?)?)?)?)?"/>
+     </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="CreationDate">
+     <xs:annotation>
+       <xs:documentation>
+         An type for encoding dates
+       </xs:documentation>
+       <xs:documentation>
+         Single values are restricted to the following forms:  YYYY, YYYY-MM,
+         or YYYY-MM-DD.  
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:simpleContent>
+       <xs:extension base="imr:Year">
+         <xs:attribute name="type" type="imr:DateType">
+            <xs:annotation>
+              <xs:documentation>
+                A label indicating the role this date plays in the lifecycle
+                of a resource.  
+              </xs:documentation>
+              <xs:documentation>
+                This is restricted to be one of the Datacite defined values.
+              </xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+       </xs:extension>
+     </xs:simpleContent>
+   </xs:complexType>
+
+   <xs:simpleType name="DateType">
+     <xs:annotation>
+       <xs:appinfo>
+         <am:dataciteproperty>dateType</am:dataciteproperty>
+       </xs:appinfo>
+       <xs:documentation>
+         A type of date (i.e. a role) important to the publishing of
+         a resource which corresponds to those defined by the Datacite
+         Metadata schema (v3.1)
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:restriction base="xs:string">
+
+       <xs:enumeration value="Accepted">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Accepted</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the date that the publisher accepted the resource
+             into their system
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Created">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Created</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the date (or date range) that the resource itself was
+             pub together.  A single date indicates when the creation was
+             completed.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Available">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Available</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the date (or date range) that the resource is made
+             publicly available
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Collected">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Collected</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the date (or date range) in which the resource content
+             was collected
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Copyrighted">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Copyrighted</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the specific, documented date at which the resource
+             receives a copyrighted status, if applicable.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+         
+       <xs:enumeration value="Issued">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Issued</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the date (or date range) that the resource is published
+             or distributed
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Submitted">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Submitted</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the date that the creator submits the resource to the
+             publisher.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Updated">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Updated</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the date (or date range) of the last update to the 
+             resource.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Valid">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Valid</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the date (or date range) during which the resource 
+             is accurate.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+     </xs:restriction>
+   </xs:simpleType>
+
+   
+
+   <xs:simpleType name="nonemptycontentStringType">
+      <xs:annotation>
+         <xs:documentation>
+           a simple type that disallows empty values
+         </xs:documentation>
+      </xs:annotation>
+
+      <xs:restriction base="xs:string">
+         <xs:minLength value="1"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+</xs:schema>
+

--- a/schemas/nmrr/xsl/imr2nmrr.xsl
+++ b/schemas/nmrr/xsl/imr2nmrr.xsl
@@ -1,10 +1,11 @@
 <?xml version="1.0"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:imr="http://schema.bipm.org/xml/imres/nmrr/nmi/1.0wd"
+                xmlns:nmi="http://schema.bipm.org/xml/imres/nmrr/nmi/1.0wd"
+                xmlns:nmdb="http://schema.bipm.org/xml/imres/nmrr/database/1.0wd"
                 xmlns:IMR="http://schema.bipm.org/xml/imres/1.0wd"
-                xmlns:nmi="http://schema.bipm.org/xml/imres/nmi/1.0wd"
+                xmlns:NMI="http://schema.bipm.org/xml/imres/nmi/1.0wd"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                exclude-result-prefixes="IMR nmi xsi"
+                exclude-result-prefixes="IMR NMI"
                 version="1.0">
                 
 <!-- Stylesheet for converting mgi-resmd records to datacite records -->
@@ -49,11 +50,12 @@
       </xsl:apply-templates>
    </xsl:template>
 
-   <xsl:template match="IMR:Resource">
+   <xsl:template match="IMR:Resource[contains(@xsi:type,':MetrologyInstitute') or
+            normalize-space(resourceType)='Organization: Metrology Institute']">
       <xsl:param name="sp"/>
       <xsl:param name="step"/>
 
-      <imr:Resource localid="{@localid}">
+      <nmi:Resource localid="{@localid}">
         
         <xsl:apply-templates select="resourceType">
           <xsl:with-param name="sp" select="concat($sp,$step)"/>
@@ -94,7 +96,94 @@
 
         <xsl:value-of select="$sp"/>
 
-      </imr:Resource>
+      </nmi:Resource>
+   </xsl:template>
+
+   <xsl:template match="IMR:Resource[contains(@xsi:type,':Database') or
+                           normalize-space(resourceType)='Dataset: Database']">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <nmdb:Resource localid="{@localid}">
+        
+        <xsl:apply-templates select="resourceType">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="title">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="altTitle[@type='Subtitle']">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="altTitle[@type='Abbreviation']">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="publisher">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="sponsoringCountry">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="publicationYear">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:choose>
+          <xsl:when test="identifier[@type='DOI']">
+            <xsl:apply-templates select="identifier" mode="doi">
+              <xsl:with-param name="sp" select="concat($sp,$step)"/>
+              <xsl:with-param name="step" select="$step"/>
+            </xsl:apply-templates>
+          </xsl:when>
+          <xsl:when test="homeURL">
+            <xsl:apply-templates select="homeURL" mode="url">
+              <xsl:with-param name="sp" select="concat($sp,$step)"/>
+              <xsl:with-param name="step" select="$step"/>
+            </xsl:apply-templates>            
+          </xsl:when>
+        </xsl:choose>
+        <xsl:apply-templates select="contact">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="creator">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="contributor">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="subject">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="description">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="date">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="measures">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="access">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+
+        <xsl:value-of select="$sp"/>
+
+      </nmdb:Resource>
    </xsl:template>
 
    <xsl:template match="sponsoringCountry">
@@ -122,6 +211,15 @@
 
       <abbreviation><xsl:value-of select="."/></abbreviation>
    </xsl:template>
+
+   <xsl:template match="altTitle[@type='Subtitle']">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <subtitle><xsl:value-of select="."/></subtitle>
+   </xsl:template>
 <!--
    <xsl:template match=""></xsl:template>
    <xsl:template match=""></xsl:template>
@@ -146,6 +244,144 @@
       <date><xsl:value-of select="."/></date>
    </xsl:template>
 
+   <xsl:template match="identifier" mode="doi">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <homePage xsi:type="nmdb:DOI">
+        <xsl:value-of select="concat($sp,$step)"/>
+        <doi><xsl:value-of select="."/></doi>
+        <xsl:value-of select="$sp"/>
+      </homePage>
+   </xsl:template>
+
+   <xsl:template match="homeURL" mode="url">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <homePage xsi:type="nmdb:HomePageURL">
+        <xsl:value-of select="concat($sp,$step)"/>
+        <url><xsl:value-of select="."/></url>
+        <xsl:value-of select="$sp"/>
+      </homePage>
+   </xsl:template>
+
+   <xsl:template match="creator">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+      <xsl:variable name="subsp" select="concat($sp,$step)"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <creator>
+        <xsl:apply-templates select="name">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="affiliation">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="identifier">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:value-of select="$sp"/>
+      </creator>
+   </xsl:template>
+
+   <xsl:template match="contributor">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+      <xsl:variable name="subsp" select="concat($sp,$step)"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <contributor type="{@type}">
+        <xsl:apply-templates select="name">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="affiliation">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="identifier">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:value-of select="$sp"/>
+      </contributor>
+   </xsl:template>
+
+   <xsl:template match="via[contains(@xsi:type,':Download')]">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+      <xsl:variable name="subsp" select="concat($sp,$step)"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <via xsi:type="">
+        <xsl:apply-templates select="format">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="accessURL">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="description">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+      </via>
+   </xsl:template>
+
+   <xsl:template match="via[contains(@xsi:type,':ServiceAPI')]">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+      <xsl:variable name="subsp" select="concat($sp,$step)"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <via xsi:type="">
+        <xsl:apply-templates select="description">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="documentationURL">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+      </via>
+   </xsl:template>
+
+   <xsl:template match="via[contains(@xsi:type,':Media')]">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+      <xsl:variable name="subsp" select="concat($sp,$step)"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <via xsi:type="">
+        <xsl:apply-templates select="mediaType">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="requestURL">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="description">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+      </via>
+   </xsl:template>
 
    <!-- default template -->
    <xsl:template match="*" priority="-1">

--- a/schemas/nmrr/xsl/imr2nmrr.xsl
+++ b/schemas/nmrr/xsl/imr2nmrr.xsl
@@ -1,0 +1,201 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:imr="http://schema.bipm.org/xml/imres/nmrr/nmi/1.0wd"
+                xmlns:IMR="http://schema.bipm.org/xml/imres/1.0wd"
+                xmlns:nmi="http://schema.bipm.org/xml/imres/nmi/1.0wd"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                exclude-result-prefixes="IMR nmi xsi"
+                version="1.0">
+                
+<!-- Stylesheet for converting mgi-resmd records to datacite records -->
+
+   <xsl:output method="xml" encoding="UTF-8" indent="no" />
+   <xsl:variable name="autoIndent" select="'  '"/>
+   <xsl:preserve-space elements="*"/>
+
+   <!--
+     -  If true, insert carriage returns and indentation to produce a neatly 
+     -  formatted output.  If false, any spacing between tags in the source
+     -  document will be preserved.  
+     -->
+   <xsl:param name="prettyPrint" select="true()"/>
+
+   <!--
+     -  the per-level indentation.  Set this to a sequence of spaces when
+     -  pretty printing is turned on.
+     -->
+   <xsl:param name="indent" select="'  '"/>
+
+
+   <xsl:variable name="cr"><xsl:text>
+</xsl:text></xsl:variable>
+
+   <!-- ==========================================================
+     -  General templates
+     -  ========================================================== -->
+
+   <xsl:template match="/">
+      <xsl:apply-templates select="*">
+         <xsl:with-param name="sp">
+            <xsl:if test="$prettyPrint">
+              <xsl:value-of select="$cr"/>
+            </xsl:if>
+         </xsl:with-param>
+         <xsl:with-param name="step">
+            <xsl:if test="$prettyPrint">
+              <xsl:value-of select="$indent"/>
+            </xsl:if>
+         </xsl:with-param>
+      </xsl:apply-templates>
+   </xsl:template>
+
+   <xsl:template match="IMR:Resource">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <imr:Resource localid="{@localid}">
+        
+        <xsl:apply-templates select="resourceType">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="title">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="altTitle">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="sponsoringCountry">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="homeURL">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="contact">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="subject">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="description">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="date">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+
+        <xsl:value-of select="$sp"/>
+
+      </imr:Resource>
+   </xsl:template>
+
+   <xsl:template match="sponsoringCountry">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <xsl:variable name="subsp" select="concat($sp,$step)"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <sponsoringCountry>
+        <xsl:value-of select="$subsp"/>
+        <name><xsl:value-of select="."/></name>
+        <xsl:value-of select="$subsp"/>
+        <abbrev><xsl:value-of select="@abbrev"/></abbrev>
+        <xsl:value-of select="$sp"/>
+      </sponsoringCountry>
+   </xsl:template>
+
+   <xsl:template match="altTitle[@type='Abbreviation']">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <abbreviation><xsl:value-of select="."/></abbreviation>
+   </xsl:template>
+<!--
+   <xsl:template match=""></xsl:template>
+   <xsl:template match=""></xsl:template>
+   <xsl:template match=""></xsl:template>
+   -->
+
+   <xsl:template match="description">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <description><xsl:value-of select="."/></description>
+   </xsl:template>
+
+   <xsl:template match="date">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <date><xsl:value-of select="."/></date>
+   </xsl:template>
+
+
+   <!-- default template -->
+   <xsl:template match="*" priority="-1">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <xsl:copy>
+         <xsl:for-each select="@*">
+            <xsl:copy/>
+         </xsl:for-each>
+
+         <xsl:apply-templates select="child::node()">
+            <xsl:with-param name="sp" select="concat($sp,$step)"/>
+            <xsl:with-param name="step" select="$step"/>
+         </xsl:apply-templates>
+
+         <xsl:if test="$prettyPrint and contains(text()[1],$cr)">
+           <xsl:value-of select="$sp"/>
+         </xsl:if>
+      </xsl:copy>
+      
+   </xsl:template>
+
+   <!--
+     -  template for handling ignorable whitespace
+     -->
+   <xsl:template match="text()" priority="-1">
+      <xsl:variable name="trimmed" select="normalize-space(.)"/>
+      <xsl:if test="not($prettyPrint) or string-length($trimmed) &gt; 0">
+         <xsl:copy/>
+      </xsl:if>
+   </xsl:template>
+
+   <xsl:template match="text()" priority="-1" mode="trim">
+      <xsl:if test="not($prettyPrint)">
+         <xsl:choose>
+            <xsl:when test="contains(.,$cr)">
+               <xsl:value-of select="$cr"/>
+               <xsl:call-template name="afterLastCR">
+                  <xsl:with-param name="text" select="."/>
+               </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+               <xsl:copy/>
+            </xsl:otherwise>
+         </xsl:choose>
+      </xsl:if>
+   </xsl:template>
+
+
+</xsl:stylesheet>

--- a/schemas/nmrr/xsl/nmrr2imr.xsl
+++ b/schemas/nmrr/xsl/nmrr2imr.xsl
@@ -1,10 +1,12 @@
 <?xml version="1.0"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:imrn="http://schema.bipm.org/xml/imres/nmrr/nmi/1.0wd"
+                xmlns:nmrn="http://schema.bipm.org/xml/imres/nmrr/nmi/1.0wd"
+                xmlns:nmrdb="http://schema.bipm.org/xml/imres/nmrr/database/1.0wd"
                 xmlns:imr="http://schema.bipm.org/xml/imres/1.0wd"
                 xmlns:nmi="http://schema.bipm.org/xml/imres/nmi/1.0wd"
+                xmlns:mdb="http://schema.bipm.org/xml/imres/nmi/1.0wd"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                exclude-result-prefixes="imrn"
+                exclude-result-prefixes="nmrn nmrdb"
                 version="1.0">
                 
 <!-- Stylesheet for converting mgi-resmd records to datacite records -->
@@ -49,21 +51,13 @@
       </xsl:apply-templates>
    </xsl:template>
 
-   <xsl:template match="imrn:Resource">
+   <xsl:template match="nmrn:Resource">
       <xsl:param name="sp"/>
       <xsl:param name="step"/>
 
       <imr:Resource xsi:type="nmi:MetrologyInstitute"
                     status="active" localid="{@localid}">
 
-      <!--
-      <xsl:element name="imr:Resource">
-        <xsl:attribute name="status">active</xsl:attribute>
-        <xsl:attribute name="localid">
-          <xsl:value-of select="@localid"/>
-        </xsl:attribute>
-        -->
-        
         <xsl:apply-templates select="resourceType">
           <xsl:with-param name="sp" select="concat($sp,$step)"/>
           <xsl:with-param name="step" select="$step"/>
@@ -96,7 +90,80 @@
           <xsl:with-param name="sp" select="concat($sp,$step)"/>
           <xsl:with-param name="step" select="$step"/>
         </xsl:apply-templates>
+        <xsl:apply-templates select="date" mode="created">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+
+        <xsl:value-of select="$sp"/>
+
+      </imr:Resource>
+   </xsl:template>
+
+   <xsl:template match="nmrdb:Resource">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <imr:Resource xsi:type="mdb:Database"
+                    status="active" localid="{@localid}">
+
+        <xsl:apply-templates select="resourceType">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="title">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="subtitle">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="abbreviation">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="homePage" mode="identifier">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="homePage" mode="homeURL">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="sponsoringCountry">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="creator">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="contributor">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="contact">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="subject">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="description">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
         <xsl:apply-templates select="date">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="publisher">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="publicationYear">
           <xsl:with-param name="sp" select="concat($sp,$step)"/>
           <xsl:with-param name="step" select="$step"/>
         </xsl:apply-templates>
@@ -123,6 +190,15 @@
       </xsl:element>
    </xsl:template>
 
+   <xsl:template match="subtitle">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <altTitle type="Subtitle"><xsl:value-of select="."/></altTitle>
+   </xsl:template>
+
    <xsl:template match="abbreviation">
       <xsl:param name="sp"/>
       <xsl:param name="step"/>
@@ -141,13 +217,95 @@
       <description><xsl:value-of select="."/></description>
    </xsl:template>
 
-   <xsl:template match="date">
+   <xsl:template match="date" mode="created">
       <xsl:param name="sp"/>
       <xsl:param name="step"/>
 
       <xsl:value-of select="$sp"/>
 
       <date type="Created"><xsl:value-of select="."/></date>
+   </xsl:template>
+
+   <xsl:template match="homePage" mode="identifier">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <xsl:if test="doi">
+         <xsl:value-of select="$sp"/>
+         <identifier type="DOI"><xsl:value-of select="doi"/></identifier>
+      </xsl:if>
+   </xsl:template>
+
+   <xsl:template match="creator[*]">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <xsl:variable name="subsp" select="concat($sp,$step)"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <creator>      
+
+         <xsl:apply-templates select="name">
+             <xsl:with-param name="sp" select="$subsp"/>
+             <xsl:with-param name="step" select="$step"/>
+         </xsl:apply-templates>
+         <xsl:apply-templates select="identifier">
+             <xsl:with-param name="sp" select="$subsp"/>
+             <xsl:with-param name="step" select="$step"/>
+         </xsl:apply-templates>
+         <xsl:apply-templates select="affiliation">
+             <xsl:with-param name="sp" select="$subsp"/>
+             <xsl:with-param name="step" select="$step"/>
+         </xsl:apply-templates>
+
+         <xsl:value-of select="$sp"/>
+
+      </creator>      
+   </xsl:template>
+
+   <xsl:template match="contributor[*]">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <xsl:variable name="subsp" select="concat($sp,$step)"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <contributor type="{@type}">      
+
+         <xsl:apply-templates select="name">
+             <xsl:with-param name="sp" select="$subsp"/>
+             <xsl:with-param name="step" select="$step"/>
+         </xsl:apply-templates>
+         <xsl:apply-templates select="identifier">
+             <xsl:with-param name="sp" select="$subsp"/>
+             <xsl:with-param name="step" select="$step"/>
+         </xsl:apply-templates>
+         <xsl:apply-templates select="affiliation">
+             <xsl:with-param name="sp" select="$subsp"/>
+             <xsl:with-param name="step" select="$step"/>
+         </xsl:apply-templates>
+
+         <xsl:value-of select="$sp"/>
+
+      </contributor>      
+   </xsl:template>
+
+   <xsl:template match="homePage" mode="homeURL">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <xsl:choose>
+         <xsl:when test="doi">
+            <xsl:value-of select="$sp"/>
+            <homeURL>http://dx.doi.org/<xsl:value-of select="doi"/></homeURL>
+         </xsl:when>
+         <xsl:when test="url">
+            <xsl:value-of select="$sp"/>
+            <homeURL><xsl:value-of select="url"/></homeURL>
+         </xsl:when>
+      </xsl:choose>
    </xsl:template>
 
    <!-- default template -->

--- a/schemas/nmrr/xsl/nmrr2imr.xsl
+++ b/schemas/nmrr/xsl/nmrr2imr.xsl
@@ -1,0 +1,204 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:imrn="http://schema.bipm.org/xml/imres/nmrr/nmi/1.0wd"
+                xmlns:imr="http://schema.bipm.org/xml/imres/1.0wd"
+                xmlns:nmi="http://schema.bipm.org/xml/imres/nmi/1.0wd"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                exclude-result-prefixes="imrn"
+                version="1.0">
+                
+<!-- Stylesheet for converting mgi-resmd records to datacite records -->
+
+   <xsl:output method="xml" encoding="UTF-8" indent="no" />
+   <xsl:variable name="autoIndent" select="'  '"/>
+   <xsl:preserve-space elements="*"/>
+
+   <!--
+     -  If true, insert carriage returns and indentation to produce a neatly 
+     -  formatted output.  If false, any spacing between tags in the source
+     -  document will be preserved.  
+     -->
+   <xsl:param name="prettyPrint" select="true()"/>
+
+   <!--
+     -  the per-level indentation.  Set this to a sequence of spaces when
+     -  pretty printing is turned on.
+     -->
+   <xsl:param name="indent" select="'  '"/>
+
+
+   <xsl:variable name="cr"><xsl:text>
+</xsl:text></xsl:variable>
+
+   <!-- ==========================================================
+     -  General templates
+     -  ========================================================== -->
+
+   <xsl:template match="/">
+      <xsl:apply-templates select="*">
+         <xsl:with-param name="sp">
+            <xsl:if test="$prettyPrint">
+              <xsl:value-of select="$cr"/>
+            </xsl:if>
+         </xsl:with-param>
+         <xsl:with-param name="step">
+            <xsl:if test="$prettyPrint">
+              <xsl:value-of select="$indent"/>
+            </xsl:if>
+         </xsl:with-param>
+      </xsl:apply-templates>
+   </xsl:template>
+
+   <xsl:template match="imrn:Resource">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <imr:Resource xsi:type="nmi:MetrologyInstitute"
+                    status="active" localid="{@localid}">
+
+      <!--
+      <xsl:element name="imr:Resource">
+        <xsl:attribute name="status">active</xsl:attribute>
+        <xsl:attribute name="localid">
+          <xsl:value-of select="@localid"/>
+        </xsl:attribute>
+        -->
+        
+        <xsl:apply-templates select="resourceType">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="title">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="abbreviation">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="homeURL">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="sponsoringCountry">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="contact">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="subject">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="description">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="date">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+
+        <xsl:value-of select="$sp"/>
+
+      <!--
+      </xsl:element>
+        -->
+      </imr:Resource>
+   </xsl:template>
+
+   <xsl:template match="sponsoringCountry">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <xsl:element name="{local-name()}">
+         <xsl:attribute name="abbrev">
+           <xsl:value-of select="abbrev"/>
+         </xsl:attribute>
+         <xsl:value-of select="name"/>
+      </xsl:element>
+   </xsl:template>
+
+   <xsl:template match="abbreviation">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <altTitle type="Abbreviation"><xsl:value-of select="."/></altTitle>
+   </xsl:template>
+
+   <xsl:template match="description">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <description><xsl:value-of select="."/></description>
+   </xsl:template>
+
+   <xsl:template match="date">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <date type="Created"><xsl:value-of select="."/></date>
+   </xsl:template>
+
+   <!-- default template -->
+   <xsl:template match="*" priority="-1">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <xsl:copy>
+         <xsl:for-each select="@*">
+            <xsl:copy/>
+         </xsl:for-each>
+
+         <xsl:apply-templates select="child::node()">
+            <xsl:with-param name="sp" select="concat($sp,$step)"/>
+            <xsl:with-param name="step" select="$step"/>
+         </xsl:apply-templates>
+
+         <xsl:if test="$prettyPrint and contains(text()[1],$cr)">
+           <xsl:value-of select="$sp"/>
+         </xsl:if>
+      </xsl:copy>
+      
+   </xsl:template>
+
+   <!--
+     -  template for handling ignorable whitespace
+     -->
+   <xsl:template match="text()" priority="-1">
+      <xsl:variable name="trimmed" select="normalize-space(.)"/>
+      <xsl:if test="not($prettyPrint) or string-length($trimmed) &gt; 0">
+         <xsl:copy/>
+      </xsl:if>
+   </xsl:template>
+
+   <xsl:template match="text()" priority="-1" mode="trim">
+      <xsl:if test="not($prettyPrint)">
+         <xsl:choose>
+            <xsl:when test="contains(.,$cr)">
+               <xsl:value-of select="$cr"/>
+               <xsl:call-template name="afterLastCR">
+                  <xsl:with-param name="text" select="."/>
+               </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+               <xsl:copy/>
+            </xsl:otherwise>
+         </xsl:choose>
+      </xsl:if>
+   </xsl:template>
+
+
+</xsl:stylesheet>

--- a/schemas/nmrr/xsl/nmrr2imr.xsl
+++ b/schemas/nmrr/xsl/nmrr2imr.xsl
@@ -4,7 +4,7 @@
                 xmlns:nmrdb="http://schema.bipm.org/xml/imres/nmrr/database/1.0wd"
                 xmlns:imr="http://schema.bipm.org/xml/imres/1.0wd"
                 xmlns:nmi="http://schema.bipm.org/xml/imres/nmi/1.0wd"
-                xmlns:mdb="http://schema.bipm.org/xml/imres/nmi/1.0wd"
+                xmlns:mdb="http://schema.bipm.org/xml/imres/data/1.0wd"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 exclude-result-prefixes="nmrn nmrdb"
                 version="1.0">
@@ -167,6 +167,14 @@
           <xsl:with-param name="sp" select="concat($sp,$step)"/>
           <xsl:with-param name="step" select="$step"/>
         </xsl:apply-templates>
+        <xsl:apply-templates select="measures">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="access">
+          <xsl:with-param name="sp" select="concat($sp,$step)"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
 
         <xsl:value-of select="$sp"/>
 
@@ -306,6 +314,110 @@
             <homeURL><xsl:value-of select="url"/></homeURL>
          </xsl:when>
       </xsl:choose>
+   </xsl:template>
+
+   <xsl:template match="via">
+     <xsl:message>Failed to match via</xsl:message>
+   </xsl:template>
+
+   <xsl:template match="via[contains(@xsi:type,':Download')]">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+      <xsl:variable name="subsp" select="concat($sp,$step)"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <xsl:element name="via">
+        <xsl:for-each select="@*">
+          <xsl:copy/>
+        </xsl:for-each>
+
+        <xsl:value-of select="$subsp"/>
+        <method>download</method>
+
+        <xsl:apply-templates select="description">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+
+        <xsl:apply-templates select="format">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="accessURL">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+
+        <xsl:value-of select="$sp"/>
+
+      </xsl:element>
+
+   </xsl:template>
+
+   <xsl:template match="via[contains(@xsi:type,':ServiceAPI')]">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+      <xsl:variable name="subsp" select="concat($sp,$step)"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <xsl:element name="via">
+        <xsl:for-each select="@*">
+          <xsl:copy/>
+        </xsl:for-each>
+
+        <xsl:value-of select="$subsp"/>
+        <method>service API</method>
+
+        <xsl:apply-templates select="description">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+
+        <xsl:apply-templates select="documentationURL">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+
+        <xsl:value-of select="$sp"/>
+
+      </xsl:element>
+
+   </xsl:template>
+
+   <xsl:template match="via[contains(@xsi:type,':Media')]">
+      <xsl:param name="sp"/>
+      <xsl:param name="step"/>
+      <xsl:variable name="subsp" select="concat($sp,$step)"/>
+
+      <xsl:value-of select="$sp"/>
+
+      <xsl:element name="via">
+        <xsl:for-each select="@*">
+          <xsl:copy/>
+        </xsl:for-each>
+
+        <xsl:value-of select="$subsp"/>
+        <method>media</method>
+
+        <xsl:apply-templates select="description">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+
+        <xsl:apply-templates select="mediaType">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="requestURL">
+          <xsl:with-param name="sp" select="$subsp"/>
+          <xsl:with-param name="step" select="$step"/>
+        </xsl:apply-templates>
+
+        <xsl:value-of select="$sp"/>
+      </xsl:element>
+
    </xsl:template>
 
    <!-- default template -->


### PR DESCRIPTION
This revision provides schemas and examples for describing metrology institutes and datasets.  The later capture metrology-specific metadata as well as information on how to access the data.  The `examples` directory includes sample instance documents.

the `schemas/nmrr` subdirectory contains versions of the schema specifically for loading into the NIST Resource Registry application which attempt to optimize the generation of more human-friendly forms.  The `schemas/nmrr/xsl` subdirectory includes a stylesheet for converting instances generated via the forms into instances that conform to the interchange schema in the `schemas` subdirectory.  
